### PR TITLE
feat: implement registration endpoint

### DIFF
--- a/backend/src/main/java/com/learnova/learnova_backend/auth/controller/AuthController.java
+++ b/backend/src/main/java/com/learnova/learnova_backend/auth/controller/AuthController.java
@@ -1,0 +1,23 @@
+package com.learnova.learnova_backend.auth.controller;
+
+import com.learnova.learnova_backend.auth.dto.RegisterRequest;
+import com.learnova.learnova_backend.auth.dto.RegisterResponse;
+import com.learnova.learnova_backend.auth.service.AuthService;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequestMapping("/api/v1/auth")
+@RequiredArgsConstructor
+public class AuthController {
+
+    private final AuthService authService;
+
+    @PostMapping("/register")
+    @ResponseStatus(HttpStatus.CREATED)
+    public RegisterResponse register(@Valid @RequestBody RegisterRequest request) {
+        return authService.register(request);
+    }
+}

--- a/backend/src/main/java/com/learnova/learnova_backend/auth/dto/RegisterRequest.java
+++ b/backend/src/main/java/com/learnova/learnova_backend/auth/dto/RegisterRequest.java
@@ -1,0 +1,22 @@
+package com.learnova.learnova_backend.auth.dto;
+
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
+
+public record RegisterRequest(
+
+        @NotBlank(message = "Full name is required")
+        @Size(max = 150, message = "Full name must not exceed 150 characters")
+        String fullName,
+
+        @NotBlank(message = "Email is required")
+        @Email(message = "Email must be valid")
+        @Size(max = 180, message = "Email must not exceed 180 characters")
+        String email,
+
+        @NotBlank(message = "Password is required")
+        @Size(min = 8, max = 100, message = "Password must be between 8 and 100 characters")
+        String password
+) {
+}

--- a/backend/src/main/java/com/learnova/learnova_backend/auth/dto/RegisterResponse.java
+++ b/backend/src/main/java/com/learnova/learnova_backend/auth/dto/RegisterResponse.java
@@ -1,0 +1,17 @@
+package com.learnova.learnova_backend.auth.dto;
+
+import com.learnova.learnova_backend.user.entity.AccountStatus;
+import com.learnova.learnova_backend.user.entity.RoleName;
+
+import java.time.Instant;
+import java.util.Set;
+
+public record RegisterResponse(
+        Long id,
+        String fullName,
+        String email,
+        AccountStatus accountStatus,
+        Set<RoleName> roles,
+        Instant createdAt
+) {
+}

--- a/backend/src/main/java/com/learnova/learnova_backend/auth/service/AuthService.java
+++ b/backend/src/main/java/com/learnova/learnova_backend/auth/service/AuthService.java
@@ -1,0 +1,84 @@
+package com.learnova.learnova_backend.auth.service;
+
+import com.learnova.learnova_backend.auth.dto.RegisterRequest;
+import com.learnova.learnova_backend.auth.dto.RegisterResponse;
+import com.learnova.learnova_backend.user.entity.AccountStatus;
+import com.learnova.learnova_backend.user.entity.Role;
+import com.learnova.learnova_backend.user.entity.RoleName;
+import com.learnova.learnova_backend.user.entity.User;
+import com.learnova.learnova_backend.user.repository.RoleRepository;
+import com.learnova.learnova_backend.user.repository.UserRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.server.ResponseStatusException;
+
+import java.util.Set;
+import java.util.stream.Collectors;
+
+@Service
+@RequiredArgsConstructor
+public class AuthService {
+
+    private final UserRepository userRepository;
+    private final RoleRepository roleRepository;
+    private final PasswordEncoder passwordEncoder;
+
+    @Transactional
+    public RegisterResponse register(RegisterRequest request) {
+        String normalizedEmail = request.email().trim().toLowerCase();
+
+        if (userRepository.existsByEmailIgnoreCase(normalizedEmail)) {
+            throw new ResponseStatusException(HttpStatus.CONFLICT, "Email is already in use");
+        }
+
+        Role learnerRole = getOrCreateRole(RoleName.ROLE_LEARNER);
+
+        User user = User.builder()
+                .fullName(request.fullName().trim())
+                .email(normalizedEmail)
+                .passwordHash(passwordEncoder.encode(request.password()))
+                .accountStatus(AccountStatus.ACTIVE)
+                .build();
+
+        user.addRole(learnerRole);
+
+        User savedUser = userRepository.save(user);
+
+        /*
+         * Learner profile creation will be implemented in the dedicated issue:
+         * "feat: create learner profile automatically after registration".
+         *
+         * This registration flow already assigns ROLE_LEARNER by default.
+         */
+
+        return toRegisterResponse(savedUser);
+    }
+
+    private Role getOrCreateRole(RoleName roleName) {
+        return roleRepository.findByName(roleName)
+                .orElseGet(() -> roleRepository.save(
+                        Role.builder()
+                                .name(roleName)
+                                .build()
+                ));
+    }
+
+    private RegisterResponse toRegisterResponse(User user) {
+        Set<RoleName> roles = user.getRoles()
+                .stream()
+                .map(Role::getName)
+                .collect(Collectors.toSet());
+
+        return new RegisterResponse(
+                user.getId(),
+                user.getFullName(),
+                user.getEmail(),
+                user.getAccountStatus(),
+                roles,
+                user.getCreatedAt()
+        );
+    }
+}

--- a/backend/src/main/java/com/learnova/learnova_backend/security/PasswordConfig.java
+++ b/backend/src/main/java/com/learnova/learnova_backend/security/PasswordConfig.java
@@ -1,0 +1,15 @@
+package com.learnova.learnova_backend.security;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.security.crypto.password.PasswordEncoder;
+
+@Configuration
+public class PasswordConfig {
+
+    @Bean
+    public PasswordEncoder passwordEncoder() {
+        return new BCryptPasswordEncoder();
+    }
+}

--- a/backend/src/main/java/com/learnova/learnova_backend/security/SecurityConfig.java
+++ b/backend/src/main/java/com/learnova/learnova_backend/security/SecurityConfig.java
@@ -1,0 +1,28 @@
+package com.learnova.learnova_backend.security;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.http.HttpMethod;
+import org.springframework.security.config.Customizer;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.web.SecurityFilterChain;
+
+@Configuration
+public class SecurityConfig {
+
+    @Bean
+    public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
+        return http
+                .csrf(csrf -> csrf.disable())
+                .authorizeHttpRequests(auth -> auth
+                        .requestMatchers(HttpMethod.POST, "/api/v1/auth/register").permitAll()
+                        .requestMatchers(
+                                "/swagger-ui/**",
+                                "/v3/api-docs/**"
+                        ).permitAll()
+                        .anyRequest().authenticated()
+                )
+                .httpBasic(Customizer.withDefaults())
+                .build();
+    }
+}

--- a/backend/src/main/java/com/learnova/learnova_backend/user/config/RoleSeeder.java
+++ b/backend/src/main/java/com/learnova/learnova_backend/user/config/RoleSeeder.java
@@ -1,4 +1,28 @@
 package com.learnova.learnova_backend.user.config;
 
-public class RoleSeeder {
+import com.learnova.learnova_backend.user.entity.Role;
+import com.learnova.learnova_backend.user.entity.RoleName;
+import com.learnova.learnova_backend.user.repository.RoleRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.boot.CommandLineRunner;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class RoleSeeder implements CommandLineRunner {
+
+    private final RoleRepository roleRepository;
+
+    @Override
+    public void run(String... args) {
+        for (RoleName roleName : RoleName.values()) {
+            if (!roleRepository.existsByName(roleName)) {
+                roleRepository.save(
+                        Role.builder()
+                                .name(roleName)
+                                .build()
+                );
+            }
+        }
+    }
 }

--- a/backend/src/main/java/com/learnova/learnova_backend/user/entity/AccountStatus.java
+++ b/backend/src/main/java/com/learnova/learnova_backend/user/entity/AccountStatus.java
@@ -1,4 +1,7 @@
 package com.learnova.learnova_backend.user.entity;
 
-public class AccountStatus {
+public enum AccountStatus {
+    ACTIVE,
+    DISABLED,
+    SUSPENDED
 }

--- a/backend/src/main/java/com/learnova/learnova_backend/user/entity/Role.java
+++ b/backend/src/main/java/com/learnova/learnova_backend/user/entity/Role.java
@@ -1,4 +1,34 @@
 package com.learnova.learnova_backend.user.entity;
 
+import jakarta.persistence.*;
+import lombok.*;
+
+import java.util.HashSet;
+import java.util.Set;
+
+@Entity
+@Table(
+        name = "roles",
+        uniqueConstraints = {
+                @UniqueConstraint(name = "uk_roles_name", columnNames = "name")
+        }
+)
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
 public class Role {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false, length = 50)
+    private RoleName name;
+
+    @ManyToMany(mappedBy = "roles")
+    @Builder.Default
+    private Set<User> users = new HashSet<>();
 }

--- a/backend/src/main/java/com/learnova/learnova_backend/user/entity/RoleName.java
+++ b/backend/src/main/java/com/learnova/learnova_backend/user/entity/RoleName.java
@@ -1,4 +1,7 @@
 package com.learnova.learnova_backend.user.entity;
 
-public class RoleName {
+public enum RoleName {
+    ROLE_LEARNER,
+    ROLE_INSTRUCTOR,
+    ROLE_ADMIN
 }

--- a/backend/src/main/java/com/learnova/learnova_backend/user/entity/User.java
+++ b/backend/src/main/java/com/learnova/learnova_backend/user/entity/User.java
@@ -1,4 +1,96 @@
 package com.learnova.learnova_backend.user.entity;
 
+import jakarta.persistence.*;
+import lombok.*;
+
+import java.time.Instant;
+import java.util.HashSet;
+import java.util.Set;
+
+@Entity
+@Table(
+        name = "users",
+        uniqueConstraints = {
+                @UniqueConstraint(name = "uk_users_email", columnNames = "email")
+        }
+)
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
 public class User {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(name = "full_name", nullable = false, length = 150)
+    private String fullName;
+
+    @Column(nullable = false, length = 180)
+    private String email;
+
+    @Column(name = "password_hash", nullable = false)
+    private String passwordHash;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "account_status", nullable = false, length = 30)
+    @Builder.Default
+    private AccountStatus accountStatus = AccountStatus.ACTIVE;
+
+    @ManyToMany(fetch = FetchType.LAZY)
+    @JoinTable(
+            name = "user_roles",
+            joinColumns = @JoinColumn(
+                    name = "user_id",
+                    nullable = false,
+                    foreignKey = @ForeignKey(name = "fk_user_roles_user")
+            ),
+            inverseJoinColumns = @JoinColumn(
+                    name = "role_id",
+                    nullable = false,
+                    foreignKey = @ForeignKey(name = "fk_user_roles_role")
+            ),
+            uniqueConstraints = {
+                    @UniqueConstraint(
+                            name = "uk_user_roles_user_role",
+                            columnNames = {"user_id", "role_id"}
+                    )
+            }
+    )
+    @Builder.Default
+    private Set<Role> roles = new HashSet<>();
+
+    @Column(name = "created_at", nullable = false, updatable = false)
+    private Instant createdAt;
+
+    @Column(name = "updated_at", nullable = false)
+    private Instant updatedAt;
+
+    @PrePersist
+    void onCreate() {
+        Instant now = Instant.now();
+        this.createdAt = now;
+        this.updatedAt = now;
+
+        if (this.accountStatus == null) {
+            this.accountStatus = AccountStatus.ACTIVE;
+        }
+    }
+
+    @PreUpdate
+    void onUpdate() {
+        this.updatedAt = Instant.now();
+    }
+
+    public void addRole(Role role) {
+        this.roles.add(role);
+        role.getUsers().add(this);
+    }
+
+    public void removeRole(Role role) {
+        this.roles.remove(role);
+        role.getUsers().remove(this);
+    }
 }

--- a/backend/src/main/java/com/learnova/learnova_backend/user/repository/RoleRepository.java
+++ b/backend/src/main/java/com/learnova/learnova_backend/user/repository/RoleRepository.java
@@ -1,4 +1,14 @@
 package com.learnova.learnova_backend.user.repository;
 
-public class RoleRepository {
+import com.learnova.learnova_backend.user.entity.Role;
+import com.learnova.learnova_backend.user.entity.RoleName;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+
+public interface RoleRepository extends JpaRepository<Role, Long> {
+
+    Optional<Role> findByName(RoleName name);
+
+    boolean existsByName(RoleName name);
 }

--- a/backend/src/main/java/com/learnova/learnova_backend/user/repository/UserRepository.java
+++ b/backend/src/main/java/com/learnova/learnova_backend/user/repository/UserRepository.java
@@ -1,4 +1,13 @@
 package com.learnova.learnova_backend.user.repository;
 
-public class UserRepository {
+import com.learnova.learnova_backend.user.entity.User;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+
+public interface UserRepository extends JpaRepository<User, Long> {
+
+    Optional<User> findByEmailIgnoreCase(String email);
+
+    boolean existsByEmailIgnoreCase(String email);
 }

--- a/backend/src/main/resources/application.yaml
+++ b/backend/src/main/resources/application.yaml
@@ -5,14 +5,20 @@ spring:
   datasource:
     url: ${DB_URL:jdbc:postgresql://localhost:5432/learnova_db}
     username: ${DB_USERNAME:learnova_user}
-    password: ${DB_PASSWORD:learnova_password}
+    password: ${DB_PASSWORD:1234}
     driver-class-name: org.postgresql.Driver
 
   jpa:
-    database-platform: org.hibernate.dialect.PostgreSQLDialect
     hibernate:
       ddl-auto: update
     open-in-view: false
     properties:
       hibernate:
         format_sql: true
+
+  sql:
+    init:
+      mode: never
+
+server:
+  port: ${SERVER_PORT:8080}

--- a/backend/src/main/resources/application.yaml
+++ b/backend/src/main/resources/application.yaml
@@ -5,7 +5,7 @@ spring:
   datasource:
     url: ${DB_URL:jdbc:postgresql://localhost:5432/learnova_db}
     username: ${DB_USERNAME:learnova_user}
-    password: ${DB_PASSWORD:1234}
+    password: ${DB_PASSWORD:learnova_password}
     driver-class-name: org.postgresql.Driver
 
   jpa:

--- a/backend/src/test/java/com/learnova/learnova_backend/auth/AuthRegistrationIntegrationTest.java
+++ b/backend/src/test/java/com/learnova/learnova_backend/auth/AuthRegistrationIntegrationTest.java
@@ -1,0 +1,108 @@
+package com.learnova.learnova_backend.auth;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.learnova.learnova_backend.auth.dto.RegisterRequest;
+import com.learnova.learnova_backend.user.repository.UserRepository;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.MediaType;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.transaction.annotation.Transactional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+@SpringBootTest
+@AutoConfigureMockMvc
+@ActiveProfiles("test")
+@Transactional
+class AuthRegistrationIntegrationTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    @Autowired
+    private UserRepository userRepository;
+
+    @Autowired
+    private PasswordEncoder passwordEncoder;
+
+    @Test
+    void shouldRegisterUserSuccessfully() throws Exception {
+        RegisterRequest request = new RegisterRequest(
+                "Massine Amakhtari",
+                "massine@example.com",
+                "password123"
+        );
+
+        String response = mockMvc.perform(post("/api/v1/auth/register")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(request)))
+                .andExpect(status().isCreated())
+                .andExpect(jsonPath("$.id").exists())
+                .andExpect(jsonPath("$.fullName").value("Massine Amakhtari"))
+                .andExpect(jsonPath("$.email").value("massine@example.com"))
+                .andExpect(jsonPath("$.accountStatus").value("ACTIVE"))
+                .andExpect(jsonPath("$.roles").isArray())
+                .andExpect(jsonPath("$.passwordHash").doesNotExist())
+                .andReturn()
+                .getResponse()
+                .getContentAsString();
+
+        JsonNode json = objectMapper.readTree(response);
+        Long userId = json.get("id").asLong();
+
+        var savedUser = userRepository.findById(userId).orElseThrow();
+
+        assertThat(savedUser.getPasswordHash()).isNotEqualTo("password123");
+        assertThat(passwordEncoder.matches("password123", savedUser.getPasswordHash())).isTrue();
+    }
+
+    @Test
+    void shouldRejectDuplicateEmail() throws Exception {
+        RegisterRequest request = new RegisterRequest(
+                "First User",
+                "duplicate@example.com",
+                "password123"
+        );
+
+        mockMvc.perform(post("/api/v1/auth/register")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(request)))
+                .andExpect(status().isCreated());
+
+        RegisterRequest duplicateRequest = new RegisterRequest(
+                "Second User",
+                "DUPLICATE@example.com",
+                "password123"
+        );
+
+        mockMvc.perform(post("/api/v1/auth/register")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(duplicateRequest)))
+                .andExpect(status().isConflict());
+    }
+
+    @Test
+    void shouldRejectInvalidRequest() throws Exception {
+        RegisterRequest request = new RegisterRequest(
+                "",
+                "invalid-email",
+                "123"
+        );
+
+        mockMvc.perform(post("/api/v1/auth/register")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(request)))
+                .andExpect(status().isBadRequest());
+    }
+}

--- a/backend/src/test/java/com/learnova/learnova_backend/user/repository/UserRepositoryTest.java
+++ b/backend/src/test/java/com/learnova/learnova_backend/user/repository/UserRepositoryTest.java
@@ -1,4 +1,79 @@
 package com.learnova.learnova_backend.user.repository;
 
-public class UserRepositoryTest {
+import com.learnova.learnova_backend.user.entity.AccountStatus;
+import com.learnova.learnova_backend.user.entity.Role;
+import com.learnova.learnova_backend.user.entity.RoleName;
+import com.learnova.learnova_backend.user.entity.User;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.test.context.ActiveProfiles;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@DataJpaTest
+@ActiveProfiles("test")
+class UserRepositoryTest {
+
+    @Autowired
+    private UserRepository userRepository;
+
+    @Autowired
+    private RoleRepository roleRepository;
+
+    @Test
+    void shouldSaveUserWithRole() {
+        Role learnerRole = roleRepository.save(
+                Role.builder()
+                        .name(RoleName.ROLE_LEARNER)
+                        .build()
+        );
+
+        User user = User.builder()
+                .fullName("Massine Amakhtari")
+                .email("massine@example.com")
+                .passwordHash("hashed-password")
+                .accountStatus(AccountStatus.ACTIVE)
+                .build();
+
+        user.addRole(learnerRole);
+
+        User savedUser = userRepository.save(user);
+
+        assertThat(savedUser.getId()).isNotNull();
+        assertThat(savedUser.getRoles()).hasSize(1);
+        assertThat(savedUser.getRoles())
+                .extracting(Role::getName)
+                .contains(RoleName.ROLE_LEARNER);
+    }
+
+    @Test
+    void shouldFindUserByEmailIgnoringCase() {
+        User user = User.builder()
+                .fullName("Test User")
+                .email("test@example.com")
+                .passwordHash("hashed-password")
+                .accountStatus(AccountStatus.ACTIVE)
+                .build();
+
+        userRepository.save(user);
+
+        assertThat(userRepository.findByEmailIgnoreCase("TEST@example.com"))
+                .isPresent();
+    }
+
+    @Test
+    void shouldCheckIfEmailExistsIgnoringCase() {
+        User user = User.builder()
+                .fullName("Test User")
+                .email("existing@example.com")
+                .passwordHash("hashed-password")
+                .accountStatus(AccountStatus.ACTIVE)
+                .build();
+
+        userRepository.save(user);
+
+        assertThat(userRepository.existsByEmailIgnoreCase("EXISTING@example.com"))
+                .isTrue();
+    }
 }


### PR DESCRIPTION
## Summary

Implemented the user registration endpoint.

## Related Issue

Closes #21

## Changes

- Added registration request and response DTOs
- Added authentication controller
- Added authentication service
- Added BCrypt password hashing
- Added duplicate email validation
- Assigned `ROLE_LEARNER` to new users by default
- Added minimal security configuration for public registration
- Added registration integration tests

## Testing

- [x] `.\mvnw clean test`
- [x] `.\mvnw clean package`
- [x] Manual POST `/api/v1/auth/register` tested

## Checklist

- [x] This PR stays within the issue scope
- [x] Code is readable and maintainable
- [x] Documentation updated if needed
- [x] No unrelated files included
- [x] No secrets or credentials committed