### PR TITLE
feat: implement current user endpoint

### DIFF
--- a/backend/src/main/java/com/learnova/learnova_backend/auth/controller/AuthController.java
+++ b/backend/src/main/java/com/learnova/learnova_backend/auth/controller/AuthController.java
@@ -1,13 +1,16 @@
 package com.learnova.learnova_backend.auth.controller;
 
+import com.learnova.learnova_backend.auth.dto.CurrentUserResponse;
 import com.learnova.learnova_backend.auth.dto.LoginRequest;
 import com.learnova.learnova_backend.auth.dto.LoginResponse;
 import com.learnova.learnova_backend.auth.dto.RegisterRequest;
 import com.learnova.learnova_backend.auth.dto.RegisterResponse;
 import com.learnova.learnova_backend.auth.service.AuthService;
+import com.learnova.learnova_backend.security.CustomUserDetails;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 
 @RestController
@@ -26,5 +29,12 @@ public class AuthController {
     @PostMapping("/login")
     public LoginResponse login(@Valid @RequestBody LoginRequest request) {
         return authService.login(request);
+    }
+
+    @GetMapping("/me")
+    public CurrentUserResponse getCurrentUser(
+            @AuthenticationPrincipal CustomUserDetails currentUser
+    ) {
+        return authService.getCurrentUser(currentUser);
     }
 }

--- a/backend/src/main/java/com/learnova/learnova_backend/auth/dto/CurrentUserResponse.java
+++ b/backend/src/main/java/com/learnova/learnova_backend/auth/dto/CurrentUserResponse.java
@@ -1,0 +1,17 @@
+package com.learnova.learnova_backend.auth.dto;
+
+import com.learnova.learnova_backend.user.entity.AccountStatus;
+import com.learnova.learnova_backend.user.entity.RoleName;
+
+import java.util.Set;
+
+public record CurrentUserResponse(
+        Long id,
+        String fullName,
+        String email,
+        AccountStatus accountStatus,
+        Set<RoleName> roles,
+        Set<String> availableProfiles,
+        String instructorApprovalStatus
+) {
+}

--- a/backend/src/main/java/com/learnova/learnova_backend/auth/service/AuthService.java
+++ b/backend/src/main/java/com/learnova/learnova_backend/auth/service/AuthService.java
@@ -1,9 +1,6 @@
 package com.learnova.learnova_backend.auth.service;
 
-import com.learnova.learnova_backend.auth.dto.LoginRequest;
-import com.learnova.learnova_backend.auth.dto.LoginResponse;
-import com.learnova.learnova_backend.auth.dto.RegisterRequest;
-import com.learnova.learnova_backend.auth.dto.RegisterResponse;
+import com.learnova.learnova_backend.auth.dto.*;
 import com.learnova.learnova_backend.security.CustomUserDetails;
 import com.learnova.learnova_backend.security.JwtService;
 import com.learnova.learnova_backend.user.entity.AccountStatus;
@@ -24,6 +21,7 @@ import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.server.ResponseStatusException;
+import com.learnova.learnova_backend.auth.dto.CurrentUserResponse;
 
 import java.util.Set;
 import java.util.stream.Collectors;
@@ -123,5 +121,21 @@ public class AuthService {
                 .stream()
                 .map(Role::getName)
                 .collect(Collectors.toSet());
+    }
+
+    @Transactional(readOnly = true)
+    public CurrentUserResponse getCurrentUser(CustomUserDetails currentUser) {
+        User user = userRepository.findByEmailIgnoreCase(currentUser.getEmail())
+                .orElseThrow(() -> new ResponseStatusException(HttpStatus.UNAUTHORIZED, "User not found"));
+
+        return new CurrentUserResponse(
+                user.getId(),
+                user.getFullName(),
+                user.getEmail(),
+                user.getAccountStatus(),
+                extractRoles(user),
+                Set.of("LEARNER"),
+                null
+        );
     }
 }

--- a/backend/src/test/java/com/learnova/learnova_backend/auth/CurrentUserIntegrationTest.java
+++ b/backend/src/test/java/com/learnova/learnova_backend/auth/CurrentUserIntegrationTest.java
@@ -1,0 +1,93 @@
+package com.learnova.learnova_backend.auth;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.learnova.learnova_backend.auth.dto.LoginRequest;
+import com.learnova.learnova_backend.auth.dto.RegisterRequest;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.MediaType;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.transaction.annotation.Transactional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+@SpringBootTest
+@AutoConfigureMockMvc
+@ActiveProfiles("test")
+@Transactional
+class CurrentUserIntegrationTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    @Test
+    void shouldReturnCurrentUserWhenAuthenticated() throws Exception {
+        String token = registerAndLogin("current@example.com", "password123");
+
+        mockMvc.perform(get("/api/v1/auth/me")
+                        .header("Authorization", "Bearer " + token))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.id").exists())
+                .andExpect(jsonPath("$.fullName").value("Massine Amakhtari"))
+                .andExpect(jsonPath("$.email").value("current@example.com"))
+                .andExpect(jsonPath("$.accountStatus").value("ACTIVE"))
+                .andExpect(jsonPath("$.roles").isArray())
+                .andExpect(jsonPath("$.availableProfiles").isArray())
+                .andExpect(jsonPath("$.availableProfiles[0]").value("LEARNER"))
+                .andExpect(jsonPath("$.password").doesNotExist())
+                .andExpect(jsonPath("$.passwordHash").doesNotExist());
+    }
+
+    @Test
+    void shouldRejectCurrentUserRequestWithoutToken() throws Exception {
+        mockMvc.perform(get("/api/v1/auth/me"))
+                .andExpect(status().isForbidden());
+    }
+
+    @Test
+    void shouldRejectCurrentUserRequestWithInvalidToken() throws Exception {
+        mockMvc.perform(get("/api/v1/auth/me")
+                        .header("Authorization", "Bearer invalid-token"))
+                .andExpect(status().isForbidden());
+    }
+
+    private String registerAndLogin(String email, String password) throws Exception {
+        RegisterRequest registerRequest = new RegisterRequest(
+                "Massine Amakhtari",
+                email,
+                password
+        );
+
+        mockMvc.perform(post("/api/v1/auth/register")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(registerRequest)))
+                .andExpect(status().isCreated());
+
+        LoginRequest loginRequest = new LoginRequest(email, password);
+
+        String loginResponse = mockMvc.perform(post("/api/v1/auth/login")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(loginRequest)))
+                .andExpect(status().isOk())
+                .andReturn()
+                .getResponse()
+                .getContentAsString();
+
+        JsonNode json = objectMapper.readTree(loginResponse);
+        String token = json.get("accessToken").asText();
+
+        assertThat(token).isNotBlank();
+
+        return token;
+    }
+}


### PR DESCRIPTION
## Summary

Implemented the current authenticated user endpoint.

## Related Issue

Closes #23

## Changes

- Added `CurrentUserResponse` DTO
- Added `GET /api/v1/auth/me`
- Returned safe authenticated user information
- Included user roles in current user response
- Included initial available profile information
- Added integration tests for authenticated and unauthenticated access

## Testing

- [ ] `.\mvnw clean test`
- [ ] `.\mvnw clean package`
- [ ] Manual GET `/api/v1/auth/me` tested with Bearer token

## Checklist

- [x] This PR stays within the issue scope
- [x] Code is readable and maintainable
- [x] Documentation updated if needed
- [x] No unrelated files included
- [x] No secrets or credentials committed