### PR TITLE
feat: create learner profile after registration

### DIFF
--- a/backend/src/main/java/com/learnova/learnova_backend/auth/service/AuthService.java
+++ b/backend/src/main/java/com/learnova/learnova_backend/auth/service/AuthService.java
@@ -22,6 +22,7 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.server.ResponseStatusException;
 import com.learnova.learnova_backend.auth.dto.CurrentUserResponse;
+import com.learnova.learnova_backend.profile.service.LearnerProfileService;
 
 import java.util.Set;
 import java.util.stream.Collectors;
@@ -35,6 +36,7 @@ public class AuthService {
     private final PasswordEncoder passwordEncoder;
     private final AuthenticationManager authenticationManager;
     private final JwtService jwtService;
+    private final LearnerProfileService learnerProfileService;
 
     @Transactional
     public RegisterResponse register(RegisterRequest request) {
@@ -56,6 +58,8 @@ public class AuthService {
         user.addRole(learnerRole);
 
         User savedUser = userRepository.save(user);
+
+        learnerProfileService.createDefaultProfileFor(savedUser);
 
         return toRegisterResponse(savedUser);
     }

--- a/backend/src/main/java/com/learnova/learnova_backend/profile/entity/LearnerProfile.java
+++ b/backend/src/main/java/com/learnova/learnova_backend/profile/entity/LearnerProfile.java
@@ -1,0 +1,65 @@
+package com.learnova.learnova_backend.profile.entity;
+
+import com.learnova.learnova_backend.user.entity.User;
+import jakarta.persistence.*;
+import lombok.*;
+
+import java.time.Instant;
+
+@Entity
+@Table(
+        name = "learner_profiles",
+        uniqueConstraints = {
+                @UniqueConstraint(name = "uk_learner_profiles_user", columnNames = "user_id")
+        }
+)
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class LearnerProfile {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @OneToOne(fetch = FetchType.LAZY, optional = false)
+    @JoinColumn(
+            name = "user_id",
+            nullable = false,
+            foreignKey = @ForeignKey(name = "fk_learner_profiles_user")
+    )
+    private User user;
+
+    @Column(name = "display_name", nullable = false, length = 150)
+    private String displayName;
+
+    @Column(length = 500)
+    private String bio;
+
+    @Column(name = "profile_image_url", length = 500)
+    private String profileImageUrl;
+
+    @Column(name = "created_at", nullable = false, updatable = false)
+    private Instant createdAt;
+
+    @Column(name = "updated_at", nullable = false)
+    private Instant updatedAt;
+
+    @PrePersist
+    void onCreate() {
+        Instant now = Instant.now();
+        this.createdAt = now;
+        this.updatedAt = now;
+
+        if (this.displayName == null && this.user != null) {
+            this.displayName = this.user.getFullName();
+        }
+    }
+
+    @PreUpdate
+    void onUpdate() {
+        this.updatedAt = Instant.now();
+    }
+}

--- a/backend/src/main/java/com/learnova/learnova_backend/profile/repository/LearnerProfileRepository.java
+++ b/backend/src/main/java/com/learnova/learnova_backend/profile/repository/LearnerProfileRepository.java
@@ -1,0 +1,13 @@
+package com.learnova.learnova_backend.profile.repository;
+
+import com.learnova.learnova_backend.profile.entity.LearnerProfile;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+
+public interface LearnerProfileRepository extends JpaRepository<LearnerProfile, Long> {
+
+    Optional<LearnerProfile> findByUserId(Long userId);
+
+    boolean existsByUserId(Long userId);
+}

--- a/backend/src/main/java/com/learnova/learnova_backend/profile/service/LearnerProfileService.java
+++ b/backend/src/main/java/com/learnova/learnova_backend/profile/service/LearnerProfileService.java
@@ -1,0 +1,27 @@
+package com.learnova.learnova_backend.profile.service;
+
+import com.learnova.learnova_backend.profile.entity.LearnerProfile;
+import com.learnova.learnova_backend.profile.repository.LearnerProfileRepository;
+import com.learnova.learnova_backend.user.entity.User;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class LearnerProfileService {
+
+    private final LearnerProfileRepository learnerProfileRepository;
+
+    public LearnerProfile createDefaultProfileFor(User user) {
+        if (learnerProfileRepository.existsByUserId(user.getId())) {
+            throw new IllegalStateException("Learner profile already exists for user");
+        }
+
+        LearnerProfile learnerProfile = LearnerProfile.builder()
+                .user(user)
+                .displayName(user.getFullName())
+                .build();
+
+        return learnerProfileRepository.save(learnerProfile);
+    }
+}

--- a/backend/src/main/java/com/learnova/learnova_backend/user/entity/User.java
+++ b/backend/src/main/java/com/learnova/learnova_backend/user/entity/User.java
@@ -2,6 +2,7 @@ package com.learnova.learnova_backend.user.entity;
 
 import jakarta.persistence.*;
 import lombok.*;
+import com.learnova.learnova_backend.profile.entity.LearnerProfile;
 
 import java.time.Instant;
 import java.util.HashSet;
@@ -92,5 +93,18 @@ public class User {
     public void removeRole(Role role) {
         this.roles.remove(role);
         role.getUsers().remove(this);
+    }
+
+    @OneToOne(
+            mappedBy = "user",
+            cascade = CascadeType.ALL,
+            orphanRemoval = true,
+            fetch = FetchType.LAZY
+    )
+    private LearnerProfile learnerProfile;
+
+    public void attachLearnerProfile(LearnerProfile learnerProfile) {
+        this.learnerProfile = learnerProfile;
+        learnerProfile.setUser(this);
     }
 }

--- a/backend/src/test/java/com/learnova/learnova_backend/profile/LearnerProfileRegistrationIntegrationTest.java
+++ b/backend/src/test/java/com/learnova/learnova_backend/profile/LearnerProfileRegistrationIntegrationTest.java
@@ -1,0 +1,96 @@
+package com.learnova.learnova_backend.profile;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.learnova.learnova_backend.auth.dto.RegisterRequest;
+import com.learnova.learnova_backend.profile.repository.LearnerProfileRepository;
+import com.learnova.learnova_backend.user.repository.UserRepository;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.MediaType;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.transaction.annotation.Transactional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@SpringBootTest
+@AutoConfigureMockMvc
+@ActiveProfiles("test")
+@Transactional
+class LearnerProfileRegistrationIntegrationTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    @Autowired
+    private UserRepository userRepository;
+
+    @Autowired
+    private LearnerProfileRepository learnerProfileRepository;
+
+    @Test
+    void shouldCreateLearnerProfileWhenUserRegisters() throws Exception {
+        RegisterRequest request = new RegisterRequest(
+                "Massine Amakhtari",
+                "learner.profile@example.com",
+                "password123"
+        );
+
+        String response = mockMvc.perform(post("/api/v1/auth/register")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(request)))
+                .andExpect(status().isCreated())
+                .andReturn()
+                .getResponse()
+                .getContentAsString();
+
+        JsonNode json = objectMapper.readTree(response);
+        Long userId = json.get("id").asLong();
+
+        var user = userRepository.findById(userId).orElseThrow();
+
+        var learnerProfile = learnerProfileRepository.findByUserId(user.getId());
+
+        assertThat(learnerProfile).isPresent();
+        assertThat(learnerProfile.get().getUser().getId()).isEqualTo(user.getId());
+        assertThat(learnerProfile.get().getDisplayName()).isEqualTo("Massine Amakhtari");
+    }
+
+    @Test
+    void shouldNotCreateLearnerProfileWhenRegistrationFailsForDuplicateEmail() throws Exception {
+        RegisterRequest request = new RegisterRequest(
+                "First User",
+                "duplicate.learner@example.com",
+                "password123"
+        );
+
+        mockMvc.perform(post("/api/v1/auth/register")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(request)))
+                .andExpect(status().isCreated());
+
+        long profileCountBeforeDuplicateAttempt = learnerProfileRepository.count();
+
+        RegisterRequest duplicateRequest = new RegisterRequest(
+                "Second User",
+                "DUPLICATE.LEARNER@example.com",
+                "password123"
+        );
+
+        mockMvc.perform(post("/api/v1/auth/register")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(duplicateRequest)))
+                .andExpect(status().isConflict());
+
+        assertThat(learnerProfileRepository.count())
+                .isEqualTo(profileCountBeforeDuplicateAttempt);
+    }
+}

--- a/backend/src/test/java/com/learnova/learnova_backend/profile/service/LearnerProfileServiceTest.java
+++ b/backend/src/test/java/com/learnova/learnova_backend/profile/service/LearnerProfileServiceTest.java
@@ -1,0 +1,46 @@
+package com.learnova.learnova_backend.profile.service;
+
+import com.learnova.learnova_backend.profile.repository.LearnerProfileRepository;
+import com.learnova.learnova_backend.user.entity.AccountStatus;
+import com.learnova.learnova_backend.user.entity.User;
+import com.learnova.learnova_backend.user.repository.UserRepository;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.transaction.annotation.Transactional;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+@SpringBootTest
+@ActiveProfiles("test")
+@Transactional
+class LearnerProfileServiceTest {
+
+    @Autowired
+    private LearnerProfileService learnerProfileService;
+
+    @Autowired
+    private UserRepository userRepository;
+
+    @Autowired
+    private LearnerProfileRepository learnerProfileRepository;
+
+    @Test
+    void shouldPreventDuplicateLearnerProfiles() {
+        User user = User.builder()
+                .fullName("Massine Amakhtari")
+                .email("duplicate.profile@example.com")
+                .passwordHash("hashed-password")
+                .accountStatus(AccountStatus.ACTIVE)
+                .build();
+
+        User savedUser = userRepository.save(user);
+
+        learnerProfileService.createDefaultProfileFor(savedUser);
+
+        assertThatThrownBy(() -> learnerProfileService.createDefaultProfileFor(savedUser))
+                .isInstanceOf(IllegalStateException.class)
+                .hasMessageContaining("Learner profile already exists");
+    }
+}


### PR DESCRIPTION
## Summary

Created learner profiles automatically during user registration.

## Related Issue

Closes #24

## Changes

- Added `LearnerProfile` entity
- Added `LearnerProfileRepository`
- Added `LearnerProfileService`
- Linked learner profiles to user accounts
- Updated registration flow to create a learner profile after user creation
- Added tests for automatic learner profile creation
- Added duplicate learner profile prevention test

## Testing

- [ ] `.\mvnw clean test`
- [ ] `.\mvnw clean package`
- [ ] Manual registration verified learner profile creation in PostgreSQL

## Checklist

- [x] This PR stays within the issue scope
- [x] Code is readable and maintainable
- [x] Documentation updated if needed
- [x] No unrelated files included
- [x] No secrets or credentials committed