### PR TITLE
feat: implement instructor profile request

### DIFF
--- a/backend/src/main/java/com/learnova/learnova_backend/auth/service/AuthService.java
+++ b/backend/src/main/java/com/learnova/learnova_backend/auth/service/AuthService.java
@@ -23,6 +23,7 @@ import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.server.ResponseStatusException;
 import com.learnova.learnova_backend.auth.dto.CurrentUserResponse;
 import com.learnova.learnova_backend.profile.service.LearnerProfileService;
+import com.learnova.learnova_backend.profile.repository.InstructorProfileRepository;
 
 import java.util.Set;
 import java.util.stream.Collectors;
@@ -37,6 +38,7 @@ public class AuthService {
     private final AuthenticationManager authenticationManager;
     private final JwtService jwtService;
     private final LearnerProfileService learnerProfileService;
+    private final InstructorProfileRepository instructorProfileRepository;
 
     @Transactional
     public RegisterResponse register(RegisterRequest request) {
@@ -132,6 +134,10 @@ public class AuthService {
         User user = userRepository.findByEmailIgnoreCase(currentUser.getEmail())
                 .orElseThrow(() -> new ResponseStatusException(HttpStatus.UNAUTHORIZED, "User not found"));
 
+        String instructorApprovalStatus = instructorProfileRepository.findByUserId(user.getId())
+                .map(profile -> profile.getApprovalStatus().name())
+                .orElse(null);
+
         return new CurrentUserResponse(
                 user.getId(),
                 user.getFullName(),
@@ -139,7 +145,7 @@ public class AuthService {
                 user.getAccountStatus(),
                 extractRoles(user),
                 Set.of("LEARNER"),
-                null
+                instructorApprovalStatus
         );
     }
 }

--- a/backend/src/main/java/com/learnova/learnova_backend/profile/controller/InstructorProfileController.java
+++ b/backend/src/main/java/com/learnova/learnova_backend/profile/controller/InstructorProfileController.java
@@ -1,0 +1,35 @@
+package com.learnova.learnova_backend.profile.controller;
+
+import com.learnova.learnova_backend.profile.dto.InstructorProfileRequest;
+import com.learnova.learnova_backend.profile.dto.InstructorProfileResponse;
+import com.learnova.learnova_backend.profile.service.InstructorProfileService;
+import com.learnova.learnova_backend.security.CustomUserDetails;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequestMapping("/api/v1/instructor-profile")
+@RequiredArgsConstructor
+public class InstructorProfileController {
+
+    private final InstructorProfileService instructorProfileService;
+
+    @PostMapping("/request")
+    @ResponseStatus(HttpStatus.CREATED)
+    public InstructorProfileResponse requestInstructorProfile(
+            @AuthenticationPrincipal CustomUserDetails currentUser,
+            @Valid @RequestBody InstructorProfileRequest request
+    ) {
+        return instructorProfileService.requestInstructorProfile(currentUser, request);
+    }
+
+    @GetMapping("/me")
+    public InstructorProfileResponse getMyInstructorProfile(
+            @AuthenticationPrincipal CustomUserDetails currentUser
+    ) {
+        return instructorProfileService.getMyInstructorProfile(currentUser);
+    }
+}

--- a/backend/src/main/java/com/learnova/learnova_backend/profile/dto/InstructorProfileRequest.java
+++ b/backend/src/main/java/com/learnova/learnova_backend/profile/dto/InstructorProfileRequest.java
@@ -1,0 +1,22 @@
+package com.learnova.learnova_backend.profile.dto;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
+
+public record InstructorProfileRequest(
+
+        @NotBlank(message = "Bio is required")
+        @Size(max = 1000, message = "Bio must not exceed 1000 characters")
+        String bio,
+
+        @NotBlank(message = "Expertise is required")
+        @Size(max = 500, message = "Expertise must not exceed 500 characters")
+        String expertise,
+
+        @Size(max = 1000, message = "Experience must not exceed 1000 characters")
+        String experience,
+
+        @Size(max = 1000, message = "Motivation must not exceed 1000 characters")
+        String motivation
+) {
+}

--- a/backend/src/main/java/com/learnova/learnova_backend/profile/dto/InstructorProfileResponse.java
+++ b/backend/src/main/java/com/learnova/learnova_backend/profile/dto/InstructorProfileResponse.java
@@ -1,0 +1,21 @@
+package com.learnova.learnova_backend.profile.dto;
+
+import com.learnova.learnova_backend.profile.entity.InstructorApprovalStatus;
+
+import java.time.Instant;
+
+public record InstructorProfileResponse(
+        Long id,
+        Long userId,
+        String fullName,
+        String email,
+        String bio,
+        String expertise,
+        String experience,
+        String motivation,
+        InstructorApprovalStatus approvalStatus,
+        String rejectionReason,
+        Instant requestedAt,
+        Instant reviewedAt
+) {
+}

--- a/backend/src/main/java/com/learnova/learnova_backend/profile/entity/InstructorApprovalStatus.java
+++ b/backend/src/main/java/com/learnova/learnova_backend/profile/entity/InstructorApprovalStatus.java
@@ -1,0 +1,7 @@
+package com.learnova.learnova_backend.profile.entity;
+
+public enum InstructorApprovalStatus {
+    PENDING,
+    APPROVED,
+    REJECTED
+}

--- a/backend/src/main/java/com/learnova/learnova_backend/profile/entity/InstructorProfile.java
+++ b/backend/src/main/java/com/learnova/learnova_backend/profile/entity/InstructorProfile.java
@@ -1,0 +1,83 @@
+package com.learnova.learnova_backend.profile.entity;
+
+import com.learnova.learnova_backend.user.entity.User;
+import jakarta.persistence.*;
+import lombok.*;
+
+import java.time.Instant;
+
+@Entity
+@Table(
+        name = "instructor_profiles",
+        uniqueConstraints = {
+                @UniqueConstraint(name = "uk_instructor_profiles_user", columnNames = "user_id")
+        }
+)
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class InstructorProfile {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @OneToOne(fetch = FetchType.LAZY, optional = false)
+    @JoinColumn(
+            name = "user_id",
+            nullable = false,
+            foreignKey = @ForeignKey(name = "fk_instructor_profiles_user")
+    )
+    private User user;
+
+    @Column(nullable = false, length = 1000)
+    private String bio;
+
+    @Column(nullable = false, length = 500)
+    private String expertise;
+
+    @Column(length = 1000)
+    private String experience;
+
+    @Column(name = "motivation", length = 1000)
+    private String motivation;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "approval_status", nullable = false, length = 30)
+    @Builder.Default
+    private InstructorApprovalStatus approvalStatus = InstructorApprovalStatus.PENDING;
+
+    @Column(name = "rejection_reason", length = 1000)
+    private String rejectionReason;
+
+    @Column(name = "requested_at", nullable = false, updatable = false)
+    private Instant requestedAt;
+
+    @Column(name = "reviewed_at")
+    private Instant reviewedAt;
+
+    @Column(name = "created_at", nullable = false, updatable = false)
+    private Instant createdAt;
+
+    @Column(name = "updated_at", nullable = false)
+    private Instant updatedAt;
+
+    @PrePersist
+    void onCreate() {
+        Instant now = Instant.now();
+        this.createdAt = now;
+        this.updatedAt = now;
+        this.requestedAt = now;
+
+        if (this.approvalStatus == null) {
+            this.approvalStatus = InstructorApprovalStatus.PENDING;
+        }
+    }
+
+    @PreUpdate
+    void onUpdate() {
+        this.updatedAt = Instant.now();
+    }
+}

--- a/backend/src/main/java/com/learnova/learnova_backend/profile/repository/InstructorProfileRepository.java
+++ b/backend/src/main/java/com/learnova/learnova_backend/profile/repository/InstructorProfileRepository.java
@@ -1,0 +1,17 @@
+package com.learnova.learnova_backend.profile.repository;
+
+import com.learnova.learnova_backend.profile.entity.InstructorApprovalStatus;
+import com.learnova.learnova_backend.profile.entity.InstructorProfile;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+import java.util.Optional;
+
+public interface InstructorProfileRepository extends JpaRepository<InstructorProfile, Long> {
+
+    Optional<InstructorProfile> findByUserId(Long userId);
+
+    boolean existsByUserId(Long userId);
+
+    List<InstructorProfile> findByApprovalStatus(InstructorApprovalStatus approvalStatus);
+}

--- a/backend/src/main/java/com/learnova/learnova_backend/profile/service/InstructorProfileService.java
+++ b/backend/src/main/java/com/learnova/learnova_backend/profile/service/InstructorProfileService.java
@@ -1,0 +1,90 @@
+package com.learnova.learnova_backend.profile.service;
+
+import com.learnova.learnova_backend.profile.dto.InstructorProfileRequest;
+import com.learnova.learnova_backend.profile.dto.InstructorProfileResponse;
+import com.learnova.learnova_backend.profile.entity.InstructorApprovalStatus;
+import com.learnova.learnova_backend.profile.entity.InstructorProfile;
+import com.learnova.learnova_backend.profile.repository.InstructorProfileRepository;
+import com.learnova.learnova_backend.security.CustomUserDetails;
+import com.learnova.learnova_backend.user.entity.User;
+import com.learnova.learnova_backend.user.repository.UserRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.server.ResponseStatusException;
+
+@Service
+@RequiredArgsConstructor
+public class InstructorProfileService {
+
+    private final InstructorProfileRepository instructorProfileRepository;
+    private final UserRepository userRepository;
+
+    @Transactional
+    public InstructorProfileResponse requestInstructorProfile(
+            CustomUserDetails currentUser,
+            InstructorProfileRequest request
+    ) {
+        User user = userRepository.findById(currentUser.getId())
+                .orElseThrow(() -> new ResponseStatusException(HttpStatus.UNAUTHORIZED, "User not found"));
+
+        if (instructorProfileRepository.existsByUserId(user.getId())) {
+            throw new ResponseStatusException(
+                    HttpStatus.CONFLICT,
+                    "Instructor profile request already exists"
+            );
+        }
+
+        InstructorProfile instructorProfile = InstructorProfile.builder()
+                .user(user)
+                .bio(request.bio().trim())
+                .expertise(request.expertise().trim())
+                .experience(normalizeOptional(request.experience()))
+                .motivation(normalizeOptional(request.motivation()))
+                .approvalStatus(InstructorApprovalStatus.PENDING)
+                .build();
+
+        InstructorProfile savedProfile = instructorProfileRepository.save(instructorProfile);
+
+        return toResponse(savedProfile);
+    }
+
+    @Transactional(readOnly = true)
+    public InstructorProfileResponse getMyInstructorProfile(CustomUserDetails currentUser) {
+        InstructorProfile instructorProfile = instructorProfileRepository.findByUserId(currentUser.getId())
+                .orElseThrow(() -> new ResponseStatusException(
+                        HttpStatus.NOT_FOUND,
+                        "Instructor profile request not found"
+                ));
+
+        return toResponse(instructorProfile);
+    }
+
+    private String normalizeOptional(String value) {
+        if (value == null || value.trim().isBlank()) {
+            return null;
+        }
+
+        return value.trim();
+    }
+
+    private InstructorProfileResponse toResponse(InstructorProfile instructorProfile) {
+        User user = instructorProfile.getUser();
+
+        return new InstructorProfileResponse(
+                instructorProfile.getId(),
+                user.getId(),
+                user.getFullName(),
+                user.getEmail(),
+                instructorProfile.getBio(),
+                instructorProfile.getExpertise(),
+                instructorProfile.getExperience(),
+                instructorProfile.getMotivation(),
+                instructorProfile.getApprovalStatus(),
+                instructorProfile.getRejectionReason(),
+                instructorProfile.getRequestedAt(),
+                instructorProfile.getReviewedAt()
+        );
+    }
+}

--- a/backend/src/main/java/com/learnova/learnova_backend/user/entity/User.java
+++ b/backend/src/main/java/com/learnova/learnova_backend/user/entity/User.java
@@ -3,6 +3,7 @@ package com.learnova.learnova_backend.user.entity;
 import jakarta.persistence.*;
 import lombok.*;
 import com.learnova.learnova_backend.profile.entity.LearnerProfile;
+import com.learnova.learnova_backend.profile.entity.InstructorProfile;
 
 import java.time.Instant;
 import java.util.HashSet;
@@ -106,5 +107,18 @@ public class User {
     public void attachLearnerProfile(LearnerProfile learnerProfile) {
         this.learnerProfile = learnerProfile;
         learnerProfile.setUser(this);
+    }
+
+    @OneToOne(
+            mappedBy = "user",
+            cascade = CascadeType.ALL,
+            orphanRemoval = true,
+            fetch = FetchType.LAZY
+    )
+    private InstructorProfile instructorProfile;
+
+    public void attachInstructorProfile(InstructorProfile instructorProfile) {
+        this.instructorProfile = instructorProfile;
+        instructorProfile.setUser(this);
     }
 }

--- a/backend/src/test/java/com/learnova/learnova_backend/profile/InstructorProfileRequestIntegrationTest.java
+++ b/backend/src/test/java/com/learnova/learnova_backend/profile/InstructorProfileRequestIntegrationTest.java
@@ -1,0 +1,190 @@
+package com.learnova.learnova_backend.profile;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.learnova.learnova_backend.auth.dto.LoginRequest;
+import com.learnova.learnova_backend.auth.dto.RegisterRequest;
+import com.learnova.learnova_backend.profile.dto.InstructorProfileRequest;
+import com.learnova.learnova_backend.profile.entity.InstructorApprovalStatus;
+import com.learnova.learnova_backend.profile.repository.InstructorProfileRepository;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.MediaType;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.transaction.annotation.Transactional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+@SpringBootTest
+@AutoConfigureMockMvc
+@ActiveProfiles("test")
+@Transactional
+class InstructorProfileRequestIntegrationTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    @Autowired
+    private InstructorProfileRepository instructorProfileRepository;
+
+    @Test
+    void shouldCreateInstructorProfileRequestWithPendingStatus() throws Exception {
+        String token = registerAndLogin("instructor.request@example.com", "password123");
+
+        InstructorProfileRequest request = new InstructorProfileRequest(
+                "I am a software engineering instructor.",
+                "Java, Spring Boot, Backend Development",
+                "3 years of tutoring and project mentoring.",
+                "I want to teach practical backend engineering."
+        );
+
+        String response = mockMvc.perform(post("/api/v1/instructor-profile/request")
+                        .header("Authorization", "Bearer " + token)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(request)))
+                .andExpect(status().isCreated())
+                .andExpect(jsonPath("$.id").exists())
+                .andExpect(jsonPath("$.approvalStatus").value("PENDING"))
+                .andExpect(jsonPath("$.bio").value("I am a software engineering instructor."))
+                .andExpect(jsonPath("$.expertise").value("Java, Spring Boot, Backend Development"))
+                .andReturn()
+                .getResponse()
+                .getContentAsString();
+
+        JsonNode json = objectMapper.readTree(response);
+        Long userId = json.get("userId").asLong();
+
+        var instructorProfile = instructorProfileRepository.findByUserId(userId);
+
+        assertThat(instructorProfile).isPresent();
+        assertThat(instructorProfile.get().getApprovalStatus())
+                .isEqualTo(InstructorApprovalStatus.PENDING);
+    }
+
+    @Test
+    void shouldRejectDuplicateInstructorProfileRequest() throws Exception {
+        String token = registerAndLogin("duplicate.instructor@example.com", "password123");
+
+        InstructorProfileRequest request = validRequest();
+
+        mockMvc.perform(post("/api/v1/instructor-profile/request")
+                        .header("Authorization", "Bearer " + token)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(request)))
+                .andExpect(status().isCreated());
+
+        mockMvc.perform(post("/api/v1/instructor-profile/request")
+                        .header("Authorization", "Bearer " + token)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(request)))
+                .andExpect(status().isConflict());
+    }
+
+    @Test
+    void shouldRejectInstructorProfileRequestWithoutAuthentication() throws Exception {
+        InstructorProfileRequest request = validRequest();
+
+        mockMvc.perform(post("/api/v1/instructor-profile/request")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(request)))
+                .andExpect(status().isForbidden());
+    }
+
+    @Test
+    void shouldRejectInvalidInstructorProfileRequest() throws Exception {
+        String token = registerAndLogin("invalid.instructor@example.com", "password123");
+
+        InstructorProfileRequest request = new InstructorProfileRequest(
+                "",
+                "",
+                null,
+                null
+        );
+
+        mockMvc.perform(post("/api/v1/instructor-profile/request")
+                        .header("Authorization", "Bearer " + token)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(request)))
+                .andExpect(status().isBadRequest());
+    }
+
+    @Test
+    void shouldReturnMyInstructorProfileRequest() throws Exception {
+        String token = registerAndLogin("my.instructor.profile@example.com", "password123");
+
+        InstructorProfileRequest request = validRequest();
+
+        mockMvc.perform(post("/api/v1/instructor-profile/request")
+                        .header("Authorization", "Bearer " + token)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(request)))
+                .andExpect(status().isCreated());
+
+        mockMvc.perform(get("/api/v1/instructor-profile/me")
+                        .header("Authorization", "Bearer " + token))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.approvalStatus").value("PENDING"))
+                .andExpect(jsonPath("$.expertise").value("Java, Spring Boot"));
+    }
+
+    @Test
+    void shouldExposeInstructorApprovalStatusInCurrentUserResponse() throws Exception {
+        String token = registerAndLogin("current.with.instructor.request@example.com", "password123");
+
+        mockMvc.perform(post("/api/v1/instructor-profile/request")
+                        .header("Authorization", "Bearer " + token)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(validRequest())))
+                .andExpect(status().isCreated());
+
+        mockMvc.perform(get("/api/v1/auth/me")
+                        .header("Authorization", "Bearer " + token))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.instructorApprovalStatus").value("PENDING"))
+                .andExpect(jsonPath("$.availableProfiles[0]").value("LEARNER"));
+    }
+
+    private InstructorProfileRequest validRequest() {
+        return new InstructorProfileRequest(
+                "I teach programming and software engineering.",
+                "Java, Spring Boot",
+                "I have experience mentoring students on backend projects.",
+                "I want to help learners build real projects."
+        );
+    }
+
+    private String registerAndLogin(String email, String password) throws Exception {
+        RegisterRequest registerRequest = new RegisterRequest(
+                "Massine Amakhtari",
+                email,
+                password
+        );
+
+        mockMvc.perform(post("/api/v1/auth/register")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(registerRequest)))
+                .andExpect(status().isCreated());
+
+        LoginRequest loginRequest = new LoginRequest(email, password);
+
+        String loginResponse = mockMvc.perform(post("/api/v1/auth/login")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(loginRequest)))
+                .andExpect(status().isOk())
+                .andReturn()
+                .getResponse()
+                .getContentAsString();
+
+        JsonNode json = objectMapper.readTree(loginResponse);
+        return json.get("accessToken").asText();
+    }
+}


### PR DESCRIPTION
## Summary

Implemented the instructor profile request workflow.

## Related Issue

Closes #25

## Changes

- Added `InstructorProfile` entity
- Added `InstructorApprovalStatus` enum
- Added `InstructorProfileRepository`
- Added instructor profile request DTO and response DTO
- Added instructor profile request service
- Added authenticated endpoint for requesting instructor access
- Added endpoint for retrieving current user's instructor profile request
- Updated `/api/v1/auth/me` to include instructor approval status when applicable
- Added integration tests for instructor profile requests and duplicate prevention

## Testing

- [ ] `.\mvnw clean test`
- [ ] `.\mvnw clean package`
- [ ] Manual POST `/api/v1/instructor-profile/request` tested

## Checklist

- [x] This PR stays within the issue scope
- [x] Code is readable and maintainable
- [x] Documentation updated if needed
- [x] No unrelated files included
- [x] No secrets or credentials committed