### PR TITLE
feat: implement admin instructor approval

### DIFF
--- a/backend/src/main/java/com/learnova/learnova_backend/profile/controller/AdminInstructorProfileController.java
+++ b/backend/src/main/java/com/learnova/learnova_backend/profile/controller/AdminInstructorProfileController.java
@@ -1,0 +1,42 @@
+package com.learnova.learnova_backend.profile.controller;
+
+import com.learnova.learnova_backend.profile.dto.InstructorProfileRejectionRequest;
+import com.learnova.learnova_backend.profile.dto.InstructorProfileResponse;
+import com.learnova.learnova_backend.profile.service.InstructorProfileService;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+@RestController
+@RequestMapping("/api/v1/admin/instructor-profiles")
+@RequiredArgsConstructor
+public class AdminInstructorProfileController {
+
+    private final InstructorProfileService instructorProfileService;
+
+    @GetMapping("/pending")
+    @PreAuthorize("hasRole('ADMIN')")
+    public List<InstructorProfileResponse> getPendingInstructorProfiles() {
+        return instructorProfileService.getPendingInstructorProfiles();
+    }
+
+    @PostMapping("/{profileId}/approve")
+    @PreAuthorize("hasRole('ADMIN')")
+    public InstructorProfileResponse approveInstructorProfile(
+            @PathVariable Long profileId
+    ) {
+        return instructorProfileService.approveInstructorProfile(profileId);
+    }
+
+    @PostMapping("/{profileId}/reject")
+    @PreAuthorize("hasRole('ADMIN')")
+    public InstructorProfileResponse rejectInstructorProfile(
+            @PathVariable Long profileId,
+            @Valid @RequestBody InstructorProfileRejectionRequest request
+    ) {
+        return instructorProfileService.rejectInstructorProfile(profileId, request);
+    }
+}

--- a/backend/src/main/java/com/learnova/learnova_backend/profile/dto/InstructorProfileRejectionRequest.java
+++ b/backend/src/main/java/com/learnova/learnova_backend/profile/dto/InstructorProfileRejectionRequest.java
@@ -1,0 +1,12 @@
+package com.learnova.learnova_backend.profile.dto;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
+
+public record InstructorProfileRejectionRequest(
+
+        @NotBlank(message = "Rejection reason is required")
+        @Size(max = 1000, message = "Rejection reason must not exceed 1000 characters")
+        String rejectionReason
+) {
+}

--- a/backend/src/main/java/com/learnova/learnova_backend/profile/service/InstructorProfileService.java
+++ b/backend/src/main/java/com/learnova/learnova_backend/profile/service/InstructorProfileService.java
@@ -13,6 +13,13 @@ import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.server.ResponseStatusException;
+import com.learnova.learnova_backend.profile.dto.InstructorProfileRejectionRequest;
+import com.learnova.learnova_backend.user.entity.Role;
+import com.learnova.learnova_backend.user.entity.RoleName;
+import com.learnova.learnova_backend.user.repository.RoleRepository;
+
+import java.time.Instant;
+import java.util.List;
 
 @Service
 @RequiredArgsConstructor
@@ -20,6 +27,7 @@ public class InstructorProfileService {
 
     private final InstructorProfileRepository instructorProfileRepository;
     private final UserRepository userRepository;
+    private final RoleRepository roleRepository;
 
     @Transactional
     public InstructorProfileResponse requestInstructorProfile(
@@ -86,5 +94,66 @@ public class InstructorProfileService {
                 instructorProfile.getRequestedAt(),
                 instructorProfile.getReviewedAt()
         );
+    }
+
+    @Transactional(readOnly = true)
+    public List<InstructorProfileResponse> getPendingInstructorProfiles() {
+        return instructorProfileRepository.findByApprovalStatus(InstructorApprovalStatus.PENDING)
+                .stream()
+                .map(this::toResponse)
+                .toList();
+    }
+
+    @Transactional
+    public InstructorProfileResponse approveInstructorProfile(Long profileId) {
+        InstructorProfile instructorProfile = instructorProfileRepository.findById(profileId)
+                .orElseThrow(() -> new ResponseStatusException(
+                        HttpStatus.NOT_FOUND,
+                        "Instructor profile request not found"
+                ));
+
+        if (instructorProfile.getApprovalStatus() == InstructorApprovalStatus.APPROVED) {
+            return toResponse(instructorProfile);
+        }
+
+        instructorProfile.setApprovalStatus(InstructorApprovalStatus.APPROVED);
+        instructorProfile.setRejectionReason(null);
+        instructorProfile.setReviewedAt(Instant.now());
+
+        Role instructorRole = getOrCreateRole(RoleName.ROLE_INSTRUCTOR);
+        instructorProfile.getUser().addRole(instructorRole);
+
+        InstructorProfile savedProfile = instructorProfileRepository.save(instructorProfile);
+
+        return toResponse(savedProfile);
+    }
+
+    @Transactional
+    public InstructorProfileResponse rejectInstructorProfile(
+            Long profileId,
+            InstructorProfileRejectionRequest request
+    ) {
+        InstructorProfile instructorProfile = instructorProfileRepository.findById(profileId)
+                .orElseThrow(() -> new ResponseStatusException(
+                        HttpStatus.NOT_FOUND,
+                        "Instructor profile request not found"
+                ));
+
+        instructorProfile.setApprovalStatus(InstructorApprovalStatus.REJECTED);
+        instructorProfile.setRejectionReason(request.rejectionReason().trim());
+        instructorProfile.setReviewedAt(Instant.now());
+
+        InstructorProfile savedProfile = instructorProfileRepository.save(instructorProfile);
+
+        return toResponse(savedProfile);
+    }
+
+    private Role getOrCreateRole(RoleName roleName) {
+        return roleRepository.findByName(roleName)
+                .orElseGet(() -> roleRepository.save(
+                        Role.builder()
+                                .name(roleName)
+                                .build()
+                ));
     }
 }

--- a/backend/src/main/java/com/learnova/learnova_backend/security/SecurityConfig.java
+++ b/backend/src/main/java/com/learnova/learnova_backend/security/SecurityConfig.java
@@ -15,9 +15,11 @@ import org.springframework.security.config.http.SessionCreationPolicy;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.security.web.SecurityFilterChain;
 import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
+import org.springframework.security.config.annotation.method.configuration.EnableMethodSecurity;
 
 @Configuration
 @EnableWebSecurity
+@EnableMethodSecurity
 @RequiredArgsConstructor
 public class SecurityConfig {
 


### PR DESCRIPTION
## Summary

Implemented admin approval and rejection workflow for instructor profile requests.

## Related Issue

Closes #26

## Changes

- Added admin endpoints for instructor profile approval management
- Added endpoint to list pending instructor profile requests
- Added endpoint to approve instructor profile requests
- Added endpoint to reject instructor profile requests
- Assigned `ROLE_INSTRUCTOR` when instructor profile is approved
- Updated current user profile availability after instructor approval
- Added method-level admin authorization with `@PreAuthorize`
- Added integration tests for admin approval, rejection, pending list, and non-admin access control

## Testing

- [ ] `.\mvnw clean test`
- [ ] `.\mvnw clean package`
- [ ] Manual admin approval flow tested

## Checklist

- [x] This PR stays within the issue scope
- [x] Code is readable and maintainable
- [x] Documentation updated if needed
- [x] No unrelated files included
- [x] No secrets or credentials committed