### PR TITLE
feat: implement profile switching logic

### DIFF
--- a/backend/src/main/java/com/learnova/learnova_backend/auth/dto/CurrentUserResponse.java
+++ b/backend/src/main/java/com/learnova/learnova_backend/auth/dto/CurrentUserResponse.java
@@ -1,5 +1,6 @@
 package com.learnova.learnova_backend.auth.dto;
 
+import com.learnova.learnova_backend.profile.entity.ProfileType;
 import com.learnova.learnova_backend.user.entity.AccountStatus;
 import com.learnova.learnova_backend.user.entity.RoleName;
 
@@ -11,7 +12,7 @@ public record CurrentUserResponse(
         String email,
         AccountStatus accountStatus,
         Set<RoleName> roles,
-        Set<String> availableProfiles,
+        Set<ProfileType> availableProfiles,
         String instructorApprovalStatus
 ) {
 }

--- a/backend/src/main/java/com/learnova/learnova_backend/auth/service/AuthService.java
+++ b/backend/src/main/java/com/learnova/learnova_backend/auth/service/AuthService.java
@@ -24,6 +24,7 @@ import org.springframework.web.server.ResponseStatusException;
 import com.learnova.learnova_backend.auth.dto.CurrentUserResponse;
 import com.learnova.learnova_backend.profile.service.LearnerProfileService;
 import com.learnova.learnova_backend.profile.repository.InstructorProfileRepository;
+import com.learnova.learnova_backend.profile.service.ProfileAccessService;
 
 import java.util.Set;
 import java.util.stream.Collectors;
@@ -39,6 +40,7 @@ public class AuthService {
     private final JwtService jwtService;
     private final LearnerProfileService learnerProfileService;
     private final InstructorProfileRepository instructorProfileRepository;
+    private final ProfileAccessService profileAccessService;
 
     @Transactional
     public RegisterResponse register(RegisterRequest request) {
@@ -144,7 +146,7 @@ public class AuthService {
                 user.getEmail(),
                 user.getAccountStatus(),
                 extractRoles(user),
-                Set.of("LEARNER"),
+                profileAccessService.resolveAvailableProfiles(user),
                 instructorApprovalStatus
         );
     }

--- a/backend/src/main/java/com/learnova/learnova_backend/profile/controller/ProfileSwitchController.java
+++ b/backend/src/main/java/com/learnova/learnova_backend/profile/controller/ProfileSwitchController.java
@@ -1,0 +1,26 @@
+package com.learnova.learnova_backend.profile.controller;
+
+import com.learnova.learnova_backend.profile.dto.ProfileSwitchRequest;
+import com.learnova.learnova_backend.profile.dto.ProfileSwitchResponse;
+import com.learnova.learnova_backend.profile.service.ProfileSwitchService;
+import com.learnova.learnova_backend.security.CustomUserDetails;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequestMapping("/api/v1/profile")
+@RequiredArgsConstructor
+public class ProfileSwitchController {
+
+    private final ProfileSwitchService profileSwitchService;
+
+    @PostMapping("/switch")
+    public ProfileSwitchResponse switchProfile(
+            @AuthenticationPrincipal CustomUserDetails currentUser,
+            @Valid @RequestBody ProfileSwitchRequest request
+    ) {
+        return profileSwitchService.switchProfile(currentUser, request);
+    }
+}

--- a/backend/src/main/java/com/learnova/learnova_backend/profile/dto/ProfileSwitchRequest.java
+++ b/backend/src/main/java/com/learnova/learnova_backend/profile/dto/ProfileSwitchRequest.java
@@ -1,0 +1,11 @@
+package com.learnova.learnova_backend.profile.dto;
+
+import com.learnova.learnova_backend.profile.entity.ProfileType;
+import jakarta.validation.constraints.NotNull;
+
+public record ProfileSwitchRequest(
+
+        @NotNull(message = "Profile type is required")
+        ProfileType profileType
+) {
+}

--- a/backend/src/main/java/com/learnova/learnova_backend/profile/dto/ProfileSwitchResponse.java
+++ b/backend/src/main/java/com/learnova/learnova_backend/profile/dto/ProfileSwitchResponse.java
@@ -1,0 +1,11 @@
+package com.learnova.learnova_backend.profile.dto;
+
+import com.learnova.learnova_backend.profile.entity.ProfileType;
+
+import java.util.Set;
+
+public record ProfileSwitchResponse(
+        ProfileType activeProfile,
+        Set<ProfileType> availableProfiles
+) {
+}

--- a/backend/src/main/java/com/learnova/learnova_backend/profile/entity/ProfileType.java
+++ b/backend/src/main/java/com/learnova/learnova_backend/profile/entity/ProfileType.java
@@ -1,0 +1,6 @@
+package com.learnova.learnova_backend.profile.entity;
+
+public enum ProfileType {
+    LEARNER,
+    INSTRUCTOR
+}

--- a/backend/src/main/java/com/learnova/learnova_backend/profile/service/ProfileAccessService.java
+++ b/backend/src/main/java/com/learnova/learnova_backend/profile/service/ProfileAccessService.java
@@ -1,0 +1,59 @@
+package com.learnova.learnova_backend.profile.service;
+
+import com.learnova.learnova_backend.profile.entity.InstructorApprovalStatus;
+import com.learnova.learnova_backend.profile.entity.ProfileType;
+import com.learnova.learnova_backend.profile.repository.InstructorProfileRepository;
+import com.learnova.learnova_backend.profile.repository.LearnerProfileRepository;
+import com.learnova.learnova_backend.user.entity.RoleName;
+import com.learnova.learnova_backend.user.entity.User;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.util.EnumSet;
+import java.util.Set;
+
+@Service
+@RequiredArgsConstructor
+public class ProfileAccessService {
+
+    private final LearnerProfileRepository learnerProfileRepository;
+    private final InstructorProfileRepository instructorProfileRepository;
+
+    public Set<ProfileType> resolveAvailableProfiles(User user) {
+        Set<ProfileType> availableProfiles = EnumSet.noneOf(ProfileType.class);
+
+        if (hasLearnerAccess(user)) {
+            availableProfiles.add(ProfileType.LEARNER);
+        }
+
+        if (hasInstructorAccess(user)) {
+            availableProfiles.add(ProfileType.INSTRUCTOR);
+        }
+
+        return availableProfiles;
+    }
+
+    public boolean canUseProfile(User user, ProfileType profileType) {
+        return resolveAvailableProfiles(user).contains(profileType);
+    }
+
+    private boolean hasLearnerAccess(User user) {
+        boolean hasLearnerRole = user.getRoles()
+                .stream()
+                .anyMatch(role -> role.getName() == RoleName.ROLE_LEARNER);
+
+        return hasLearnerRole && learnerProfileRepository.existsByUserId(user.getId());
+    }
+
+    private boolean hasInstructorAccess(User user) {
+        boolean hasInstructorRole = user.getRoles()
+                .stream()
+                .anyMatch(role -> role.getName() == RoleName.ROLE_INSTRUCTOR);
+
+        boolean hasApprovedInstructorProfile = instructorProfileRepository.findByUserId(user.getId())
+                .map(profile -> profile.getApprovalStatus() == InstructorApprovalStatus.APPROVED)
+                .orElse(false);
+
+        return hasInstructorRole && hasApprovedInstructorProfile;
+    }
+}

--- a/backend/src/main/java/com/learnova/learnova_backend/profile/service/ProfileSwitchService.java
+++ b/backend/src/main/java/com/learnova/learnova_backend/profile/service/ProfileSwitchService.java
@@ -1,0 +1,44 @@
+package com.learnova.learnova_backend.profile.service;
+
+import com.learnova.learnova_backend.profile.dto.ProfileSwitchRequest;
+import com.learnova.learnova_backend.profile.dto.ProfileSwitchResponse;
+import com.learnova.learnova_backend.profile.entity.ProfileType;
+import com.learnova.learnova_backend.security.CustomUserDetails;
+import com.learnova.learnova_backend.user.entity.User;
+import com.learnova.learnova_backend.user.repository.UserRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.server.ResponseStatusException;
+
+@Service
+@RequiredArgsConstructor
+public class ProfileSwitchService {
+
+    private final UserRepository userRepository;
+    private final ProfileAccessService profileAccessService;
+
+    @Transactional(readOnly = true)
+    public ProfileSwitchResponse switchProfile(
+            CustomUserDetails currentUser,
+            ProfileSwitchRequest request
+    ) {
+        User user = userRepository.findById(currentUser.getId())
+                .orElseThrow(() -> new ResponseStatusException(HttpStatus.UNAUTHORIZED, "User not found"));
+
+        ProfileType requestedProfile = request.profileType();
+
+        if (!profileAccessService.canUseProfile(user, requestedProfile)) {
+            throw new ResponseStatusException(
+                    HttpStatus.FORBIDDEN,
+                    "Requested profile is not available for this user"
+            );
+        }
+
+        return new ProfileSwitchResponse(
+                requestedProfile,
+                profileAccessService.resolveAvailableProfiles(user)
+        );
+    }
+}

--- a/backend/src/test/java/com/learnova/learnova_backend/profile/ProfileSwitchIntegrationTest.java
+++ b/backend/src/test/java/com/learnova/learnova_backend/profile/ProfileSwitchIntegrationTest.java
@@ -1,0 +1,226 @@
+package com.learnova.learnova_backend.profile;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.learnova.learnova_backend.auth.dto.LoginRequest;
+import com.learnova.learnova_backend.auth.dto.RegisterRequest;
+import com.learnova.learnova_backend.profile.dto.InstructorProfileRequest;
+import com.learnova.learnova_backend.profile.dto.ProfileSwitchRequest;
+import com.learnova.learnova_backend.profile.entity.ProfileType;
+import com.learnova.learnova_backend.user.entity.Role;
+import com.learnova.learnova_backend.user.entity.RoleName;
+import com.learnova.learnova_backend.user.entity.User;
+import com.learnova.learnova_backend.user.repository.RoleRepository;
+import com.learnova.learnova_backend.user.repository.UserRepository;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.MediaType;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.transaction.annotation.Transactional;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+@SpringBootTest
+@AutoConfigureMockMvc
+@ActiveProfiles("test")
+@Transactional
+class ProfileSwitchIntegrationTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    @Autowired
+    private UserRepository userRepository;
+
+    @Autowired
+    private RoleRepository roleRepository;
+
+    @Autowired
+    private PasswordEncoder passwordEncoder;
+
+    @Test
+    void learnerProfileShouldAlwaysBeAvailableForRegisteredUser() throws Exception {
+        String token = registerAndLogin("learner.switch@example.com", "password123");
+
+        mockMvc.perform(get("/api/v1/auth/me")
+                        .header("Authorization", "Bearer " + token))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.availableProfiles").isArray())
+                .andExpect(jsonPath("$.availableProfiles[0]").value("LEARNER"));
+    }
+
+    @Test
+    void shouldAllowSwitchingToLearnerProfile() throws Exception {
+        String token = registerAndLogin("switch.learner@example.com", "password123");
+
+        ProfileSwitchRequest request = new ProfileSwitchRequest(ProfileType.LEARNER);
+
+        mockMvc.perform(post("/api/v1/profile/switch")
+                        .header("Authorization", "Bearer " + token)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(request)))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.activeProfile").value("LEARNER"))
+                .andExpect(jsonPath("$.availableProfiles").isArray());
+    }
+
+    @Test
+    void shouldRejectSwitchingToInstructorProfileWhenNotApproved() throws Exception {
+        String token = registerAndLogin("not.approved.switch@example.com", "password123");
+
+        ProfileSwitchRequest request = new ProfileSwitchRequest(ProfileType.INSTRUCTOR);
+
+        mockMvc.perform(post("/api/v1/profile/switch")
+                        .header("Authorization", "Bearer " + token)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(request)))
+                .andExpect(status().isForbidden());
+    }
+
+    @Test
+    void shouldAllowSwitchingToInstructorProfileAfterApproval() throws Exception {
+        String adminToken = createAdminAndLogin("admin.switch@example.com", "password123");
+
+        String teacherEmail = "approved.switch.teacher@example.com";
+        String teacherPassword = "password123";
+
+        Long profileId = createInstructorRequest(teacherEmail, teacherPassword);
+
+        mockMvc.perform(post("/api/v1/admin/instructor-profiles/{profileId}/approve", profileId)
+                        .header("Authorization", "Bearer " + adminToken))
+                .andExpect(status().isOk());
+
+        String teacherToken = login(teacherEmail, teacherPassword);
+
+        ProfileSwitchRequest request = new ProfileSwitchRequest(ProfileType.INSTRUCTOR);
+
+        mockMvc.perform(post("/api/v1/profile/switch")
+                        .header("Authorization", "Bearer " + teacherToken)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(request)))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.activeProfile").value("INSTRUCTOR"))
+                .andExpect(jsonPath("$.availableProfiles").isArray());
+    }
+
+    @Test
+    void currentUserShouldReturnInstructorProfileOnlyAfterApproval() throws Exception {
+        String adminToken = createAdminAndLogin("admin.available.profile@example.com", "password123");
+
+        String teacherEmail = "available.profile.teacher@example.com";
+        String teacherPassword = "password123";
+
+        Long profileId = createInstructorRequest(teacherEmail, teacherPassword);
+
+        String pendingTeacherToken = login(teacherEmail, teacherPassword);
+
+        mockMvc.perform(get("/api/v1/auth/me")
+                        .header("Authorization", "Bearer " + pendingTeacherToken))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.instructorApprovalStatus").value("PENDING"))
+                .andExpect(jsonPath("$.availableProfiles[0]").value("LEARNER"));
+
+        mockMvc.perform(post("/api/v1/admin/instructor-profiles/{profileId}/approve", profileId)
+                        .header("Authorization", "Bearer " + adminToken))
+                .andExpect(status().isOk());
+
+        String approvedTeacherToken = login(teacherEmail, teacherPassword);
+
+        mockMvc.perform(get("/api/v1/auth/me")
+                        .header("Authorization", "Bearer " + approvedTeacherToken))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.instructorApprovalStatus").value("APPROVED"))
+                .andExpect(jsonPath("$.availableProfiles").isArray());
+    }
+
+    private Long createInstructorRequest(String email, String password) throws Exception {
+        String token = registerAndLogin(email, password);
+
+        InstructorProfileRequest request = new InstructorProfileRequest(
+                "I teach backend engineering.",
+                "Java, Spring Boot",
+                "I have experience mentoring backend projects.",
+                "I want to teach practical software engineering."
+        );
+
+        String response = mockMvc.perform(post("/api/v1/instructor-profile/request")
+                        .header("Authorization", "Bearer " + token)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(request)))
+                .andExpect(status().isCreated())
+                .andReturn()
+                .getResponse()
+                .getContentAsString();
+
+        JsonNode json = objectMapper.readTree(response);
+        return json.get("id").asLong();
+    }
+
+    private String createAdminAndLogin(String email, String password) throws Exception {
+        Role adminRole = roleRepository.findByName(RoleName.ROLE_ADMIN)
+                .orElseGet(() -> roleRepository.save(
+                        Role.builder()
+                                .name(RoleName.ROLE_ADMIN)
+                                .build()
+                ));
+
+        Role learnerRole = roleRepository.findByName(RoleName.ROLE_LEARNER)
+                .orElseGet(() -> roleRepository.save(
+                        Role.builder()
+                                .name(RoleName.ROLE_LEARNER)
+                                .build()
+                ));
+
+        User admin = User.builder()
+                .fullName("Admin User")
+                .email(email)
+                .passwordHash(passwordEncoder.encode(password))
+                .build();
+
+        admin.addRole(learnerRole);
+        admin.addRole(adminRole);
+
+        userRepository.save(admin);
+
+        return login(email, password);
+    }
+
+    private String registerAndLogin(String email, String password) throws Exception {
+        RegisterRequest registerRequest = new RegisterRequest(
+                "Massine Amakhtari",
+                email,
+                password
+        );
+
+        mockMvc.perform(post("/api/v1/auth/register")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(registerRequest)))
+                .andExpect(status().isCreated());
+
+        return login(email, password);
+    }
+
+    private String login(String email, String password) throws Exception {
+        LoginRequest loginRequest = new LoginRequest(email, password);
+
+        String loginResponse = mockMvc.perform(post("/api/v1/auth/login")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(loginRequest)))
+                .andExpect(status().isOk())
+                .andReturn()
+                .getResponse()
+                .getContentAsString();
+
+        JsonNode json = objectMapper.readTree(loginResponse);
+        return json.get("accessToken").asText();
+    }
+}

--- a/docs/README.md
+++ b/docs/README.md
@@ -8,6 +8,7 @@ This folder contains the technical documentation for the Online Training Platfor
 - [Backend Modules](architecture/modules.md)
 - [Data Model](architecture/data-model.md)
 - [API Overview](architecture/api-overview.md)
+- [Profile Switching](architecture/profile-switching.md)
 
 ## Architecture Decisions
 

--- a/docs/architecture/profile-switching.md
+++ b/docs/architecture/profile-switching.md
@@ -1,0 +1,38 @@
+# Profile Switching
+
+Learnova supports a dual-profile model.
+
+A registered user receives a learner profile by default. The same user may request instructor access. After admin approval, the user receives instructor access and can switch between learner mode and instructor mode in the frontend.
+
+## Backend Responsibility
+
+The backend is responsible for validating which profiles are available to the authenticated user.
+
+A learner profile is available when:
+
+- the user has `ROLE_LEARNER`
+- the user has a learner profile record
+
+An instructor profile is available when:
+
+- the user has `ROLE_INSTRUCTOR`
+- the user has an instructor profile record
+- the instructor profile has `APPROVED` status
+
+## Frontend Responsibility
+
+The frontend may store the selected active profile locally.
+
+The backend does not persist active profile state in the first version. Instead, it exposes available profiles through:
+
+```text
+GET /api/v1/auth/me
+```
+and validates profile switch requests through:
+
+```text
+POST /api/v1/profile/switch
+```
+
+## Reasoning
+Keeping active profile state on the frontend keeps the backend stateless and avoids unnecessary session persistence. Backend authorization remains role-based and profile-aware.


### PR DESCRIPTION
## Summary

Implemented backend support for dual-profile switching.

## Related Issue

Closes #27

## Changes

- Added `ProfileType` enum
- Added profile switch request and response DTOs
- Added profile access validation service
- Added profile switch service
- Added `POST /api/v1/profile/switch`
- Updated `/api/v1/auth/me` to return available profiles based on roles, profile existence, and instructor approval status
- Added profile switching architecture documentation
- Added integration tests for learner and instructor profile availability

## Testing

- [x] `.\mvnw clean test`
- [x] `.\mvnw clean package`
- [x] Manual admin approval flow tested
- [x] Manual `GET /api/v1/auth/me` tested
- [x] Manual `POST /api/v1/profile/switch` tested

## Manual Verification

Approved instructor response:

```json
{
  "approvalStatus": "APPROVED"
}
```

Current user response after approval:
```json
{
  "roles": ["ROLE_INSTRUCTOR", "ROLE_LEARNER"],
  "availableProfiles": ["LEARNER", "INSTRUCTOR"],
  "instructorApprovalStatus": "APPROVED"
}
```
Profile switch response:
```json
{
  "activeProfile": "INSTRUCTOR",
  "availableProfiles": ["LEARNER", "INSTRUCTOR"]
}
```

### Checklist
- [x] This PR stays within the issue scope
- [x] Code is readable and maintainable
- [x] Documentation updated if needed
- [x] No unrelated files included
- [x] No secrets or credentials committed