### PR TITLE
feat: add authentication pages

### DIFF
--- a/frontend/src/context/AuthContext.tsx
+++ b/frontend/src/context/AuthContext.tsx
@@ -1,0 +1,58 @@
+import { createContext, useContext, useState, ReactNode } from 'react';
+
+interface User {
+    id: number;
+    fullName: string;
+    email: string;
+    roles: string[];
+    availableProfiles: string[];
+    instructorApprovalStatus: string | null;
+}
+
+interface AuthContextType {
+    user: User | null;
+    token: string | null;
+    login: (token: string, user: User) => void;
+    logout: () => void;
+    isAuthenticated: boolean;
+}
+
+const AuthContext = createContext<AuthContextType | null>(null);
+
+export function AuthProvider({ children }: { children: ReactNode }) {
+    const [token, setToken] = useState<string | null>(
+        localStorage.getItem('token')
+    );
+    const [user, setUser] = useState<User | null>(() => {
+        const stored = localStorage.getItem('user');
+        return stored ? JSON.parse(stored) : null;
+    });
+
+    function login(token: string, user: User) {
+        localStorage.setItem('token', token);
+        localStorage.setItem('user', JSON.stringify(user));
+        setToken(token);
+        setUser(user);
+    }
+
+    function logout() {
+        localStorage.removeItem('token');
+        localStorage.removeItem('user');
+        setToken(null);
+        setUser(null);
+    }
+
+    return (
+        <AuthContext.Provider
+            value={{ user, token, login, logout, isAuthenticated: !!token }}
+        >
+            {children}
+        </AuthContext.Provider>
+    );
+}
+
+export function useAuth() {
+    const context = useContext(AuthContext);
+    if (!context) throw new Error('useAuth must be used within AuthProvider');
+    return context;
+}

--- a/frontend/src/features/auth/pages/LoginPage.tsx
+++ b/frontend/src/features/auth/pages/LoginPage.tsx
@@ -1,0 +1,107 @@
+import { useState } from 'react';
+import { useNavigate, Link } from 'react-router-dom';
+import api from '../../../api/axios';
+import { useAuth } from '../../../context/AuthContext';
+
+export default function LoginPage() {
+    const { login } = useAuth();
+    const navigate = useNavigate();
+
+    const [email, setEmail] = useState('');
+    const [password, setPassword] = useState('');
+    const [error, setError] = useState<string | null>(null);
+    const [loading, setLoading] = useState(false);
+
+    async function handleSubmit(e: React.FormEvent) {
+        e.preventDefault();
+        setError(null);
+        setLoading(true);
+
+        try {
+            const { data } = await api.post('/api/v1/auth/login', { email, password });
+            login(data.accessToken, {
+                id: data.userId,
+                fullName: data.fullName,
+                email: data.email,
+                roles: data.roles,
+                availableProfiles: [],
+                instructorApprovalStatus: null,
+            });
+            navigate('/');
+        } catch (err: any) {
+            const message = err.response?.data?.message || 'Invalid credentials';
+            setError(message);
+        } finally {
+            setLoading(false);
+        }
+    }
+
+    return (
+        <div style={styles.container}>
+            <div style={styles.card}>
+                <h1 style={styles.title}>Learnova</h1>
+                <h2 style={styles.subtitle}>Sign in to your account</h2>
+
+                {error && <p style={styles.error}>{error}</p>}
+
+                <form onSubmit={handleSubmit} style={styles.form}>
+                    <label style={styles.label}>Email</label>
+                    <input
+                        type="email"
+                        value={email}
+                        onChange={(e) => setEmail(e.target.value)}
+                        required
+                        style={styles.input}
+                        placeholder="you@example.com"
+                    />
+
+                    <label style={styles.label}>Password</label>
+                    <input
+                        type="password"
+                        value={password}
+                        onChange={(e) => setPassword(e.target.value)}
+                        required
+                        style={styles.input}
+                        placeholder="••••••••"
+                    />
+
+                    <button type="submit" disabled={loading} style={styles.button}>
+                        {loading ? 'Signing in...' : 'Sign in'}
+                    </button>
+                </form>
+
+                <p style={styles.footer}>
+                    Don't have an account?{' '}
+                    <Link to="/register" style={styles.link}>Register</Link>
+                </p>
+            </div>
+        </div>
+    );
+}
+
+const styles: Record<string, React.CSSProperties> = {
+    container: {
+        minHeight: '100vh',
+        display: 'flex',
+        alignItems: 'center',
+        justifyContent: 'center',
+        backgroundColor: '#f5f5f5',
+    },
+    card: {
+        backgroundColor: '#fff',
+        padding: '2rem',
+        borderRadius: '8px',
+        boxShadow: '0 2px 8px rgba(0,0,0,0.1)',
+        width: '100%',
+        maxWidth: '400px',
+    },
+    title: { textAlign: 'center', marginBottom: '0.25rem' },
+    subtitle: { textAlign: 'center', fontWeight: 400, marginBottom: '1.5rem', color: '#555' },
+    error: { color: '#c0392b', backgroundColor: '#fdecea', padding: '0.75rem', borderRadius: '4px', marginBottom: '1rem' },
+    form: { display: 'flex', flexDirection: 'column', gap: '0.75rem' },
+    label: { fontWeight: 500, fontSize: '0.9rem' },
+    input: { padding: '0.6rem 0.75rem', borderRadius: '4px', border: '1px solid #ccc', fontSize: '1rem' },
+    button: { marginTop: '0.5rem', padding: '0.75rem', backgroundColor: '#2c3e50', color: '#fff', border: 'none', borderRadius: '4px', fontSize: '1rem', cursor: 'pointer' },
+    footer: { textAlign: 'center', marginTop: '1.25rem', fontSize: '0.9rem' },
+    link: { color: '#2c3e50', fontWeight: 500 },
+};

--- a/frontend/src/features/auth/pages/RegisterPage.tsx
+++ b/frontend/src/features/auth/pages/RegisterPage.tsx
@@ -1,0 +1,109 @@
+import { useState } from 'react';
+import { useNavigate, Link } from 'react-router-dom';
+import api from '../../../api/axios';
+
+export default function RegisterPage() {
+    const navigate = useNavigate();
+
+    const [fullName, setFullName] = useState('');
+    const [email, setEmail] = useState('');
+    const [password, setPassword] = useState('');
+    const [error, setError] = useState<string | null>(null);
+    const [loading, setLoading] = useState(false);
+
+    async function handleSubmit(e: React.FormEvent) {
+        e.preventDefault();
+        setError(null);
+        setLoading(true);
+
+        try {
+            await api.post('/api/v1/auth/register', { fullName, email, password });
+            navigate('/login');
+        } catch (err: any) {
+            const message = err.response?.data?.message || 'Registration failed';
+            setError(message);
+        } finally {
+            setLoading(false);
+        }
+    }
+
+    return (
+        <div style={styles.container}>
+            <div style={styles.card}>
+                <h1 style={styles.title}>Learnova</h1>
+                <h2 style={styles.subtitle}>Create your account</h2>
+
+                {error && <p style={styles.error}>{error}</p>}
+
+                <form onSubmit={handleSubmit} style={styles.form}>
+                    <label style={styles.label}>Full name</label>
+                    <input
+                        type="text"
+                        value={fullName}
+                        onChange={(e) => setFullName(e.target.value)}
+                        required
+                        style={styles.input}
+                        placeholder="Massine Amakhtari"
+                    />
+
+                    <label style={styles.label}>Email</label>
+                    <input
+                        type="email"
+                        value={email}
+                        onChange={(e) => setEmail(e.target.value)}
+                        required
+                        style={styles.input}
+                        placeholder="you@example.com"
+                    />
+
+                    <label style={styles.label}>Password</label>
+                    <input
+                        type="password"
+                        value={password}
+                        onChange={(e) => setPassword(e.target.value)}
+                        required
+                        minLength={8}
+                        style={styles.input}
+                        placeholder="At least 8 characters"
+                    />
+
+                    <button type="submit" disabled={loading} style={styles.button}>
+                        {loading ? 'Creating account...' : 'Register'}
+                    </button>
+                </form>
+
+                <p style={styles.footer}>
+                    Already have an account?{' '}
+                    <Link to="/login" style={styles.link}>Sign in</Link>
+                </p>
+            </div>
+        </div>
+    );
+}
+
+const styles: Record<string, React.CSSProperties> = {
+    container: {
+        minHeight: '100vh',
+        display: 'flex',
+        alignItems: 'center',
+        justifyContent: 'center',
+        backgroundColor: '#f5f5f5',
+    },
+    card: {
+        backgroundColor: '#fff',
+        padding: '2rem',
+        borderRadius: '8px',
+        boxShadow: '0 2px 8px rgba(0,0,0,0.1)',
+        width: '100%',
+        maxWidth: '400px',
+    },
+    title: { textAlign: 'center', marginBottom: '0.25rem' },
+    subtitle: { textAlign: 'center', fontWeight: 400, marginBottom: '1.5rem', color: '#555' },
+    error: { color: '#c0392b', backgroundColor: '#fdecea', padding: '0.75rem', borderRadius: '4px', marginBottom: '1rem' },
+    form: { display: 'flex', flexDirection: 'column', gap: '0.75rem' },
+    label: { fontWeight: 500, fontSize: '0.9rem' },
+    input: { padding: '0.6rem 0.75rem', borderRadius: '4px', border: '1px solid #ccc', fontSize: '1rem' },
+    button: { marginTop: '0.5rem', padding: '0.75rem', backgroundColor: '#2c3e50', color: '#fff', border: 'none', borderRadius: '4px', fontSize: '1rem', cursor: 'pointer' },
+    footer: { textAlign: 'center', marginTop: '1.25rem', fontSize: '0.9rem' },
+    link: { color: '#2c3e50', fontWeight: 500 },
+};

--- a/frontend/src/main.tsx
+++ b/frontend/src/main.tsx
@@ -1,10 +1,13 @@
 import React from 'react';
 import ReactDOM from 'react-dom/client';
 import App from './App';
+import { AuthProvider } from './context/AuthContext';
 import './index.css';
 
 ReactDOM.createRoot(document.getElementById('root')!).render(
     <React.StrictMode>
-        <App />
+        <AuthProvider>
+            <App />
+        </AuthProvider>
     </React.StrictMode>
 );

--- a/frontend/src/router/index.tsx
+++ b/frontend/src/router/index.tsx
@@ -1,10 +1,20 @@
 import { createBrowserRouter } from 'react-router-dom';
+import LoginPage from '../features/auth/pages/LoginPage';
+import RegisterPage from '../features/auth/pages/RegisterPage';
 import NotFoundPage from '../pages/NotFoundPage';
 
 const router = createBrowserRouter([
     {
         path: '/',
-        element: <div>Learnova</div>,
+        element: <div>Learnova — Dashboard coming soon</div>,
+    },
+    {
+        path: '/login',
+        element: <LoginPage />,
+    },
+    {
+        path: '/register',
+        element: <RegisterPage />,
     },
     {
         path: '*',


### PR DESCRIPTION
## Summary
Add login and register pages connected to the backend auth endpoints.

## Related Issue
Closes #29

## Changes
- Created AuthContext with login/logout and localStorage persistence
- Added LoginPage calling POST /api/v1/auth/login
- Added RegisterPage calling POST /api/v1/auth/register
- Registered /login and /register routes in the router
- Wrapped app with AuthProvider in main.tsx
- Basic inline styling for both pages

## Testing
- Register with a new email → redirects to /login
- Login with valid credentials → redirects to /
- Login with wrong credentials → shows error message
- Token and user stored in localStorage after login

## Checklist
- [x] This PR stays within the issue scope
- [x] No protected routes implemented (that is #30)
- [x] No profile switcher implemented (that is #31)
- [x] No secrets committed