### PR TITLE
feat: add protected routes

### DIFF
--- a/frontend/src/components/common/GuestRoute.tsx
+++ b/frontend/src/components/common/GuestRoute.tsx
@@ -1,0 +1,16 @@
+import { Navigate } from 'react-router-dom';
+import { useAuth } from '../../context/AuthContext';
+
+interface GuestRouteProps {
+    children: React.ReactNode;
+}
+
+export default function GuestRoute({ children }: GuestRouteProps) {
+    const { isAuthenticated } = useAuth();
+
+    if (isAuthenticated) {
+        return <Navigate to="/" replace />;
+    }
+
+    return <>{children}</>;
+}

--- a/frontend/src/components/common/ProtectedRoute.tsx
+++ b/frontend/src/components/common/ProtectedRoute.tsx
@@ -1,0 +1,16 @@
+import { Navigate } from 'react-router-dom';
+import { useAuth } from '../../context/AuthContext';
+
+interface ProtectedRouteProps {
+    children: React.ReactNode;
+}
+
+export default function ProtectedRoute({ children }: ProtectedRouteProps) {
+    const { isAuthenticated } = useAuth();
+
+    if (!isAuthenticated) {
+        return <Navigate to="/login" replace />;
+    }
+
+    return <>{children}</>;
+}

--- a/frontend/src/pages/DashboardPlaceholder.tsx
+++ b/frontend/src/pages/DashboardPlaceholder.tsx
@@ -1,0 +1,20 @@
+import { useAuth } from '../context/AuthContext';
+import { useNavigate } from 'react-router-dom';
+
+export default function DashboardPlaceholder() {
+    const { user, logout } = useAuth();
+    const navigate = useNavigate();
+
+    function handleLogout() {
+        logout();
+        navigate('/login');
+    }
+
+    return (
+        <div style={{ padding: '2rem' }}>
+            <h1>Welcome, {user?.fullName}</h1>
+            <p>Roles: {user?.roles.join(', ')}</p>
+            <button onClick={handleLogout}>Logout</button>
+        </div>
+    );
+}

--- a/frontend/src/router/index.tsx
+++ b/frontend/src/router/index.tsx
@@ -2,19 +2,34 @@ import { createBrowserRouter } from 'react-router-dom';
 import LoginPage from '../features/auth/pages/LoginPage';
 import RegisterPage from '../features/auth/pages/RegisterPage';
 import NotFoundPage from '../pages/NotFoundPage';
+import ProtectedRoute from '../components/common/ProtectedRoute';
+import GuestRoute from '../components/common/GuestRoute';
+import DashboardPlaceholder from '../pages/DashboardPlaceholder';
 
 const router = createBrowserRouter([
     {
         path: '/',
-        element: <div>Learnova — Dashboard coming soon</div>,
+        element: (
+            <ProtectedRoute>
+                <DashboardPlaceholder />
+            </ProtectedRoute>
+        ),
     },
     {
         path: '/login',
-        element: <LoginPage />,
+        element: (
+            <GuestRoute>
+                <LoginPage />
+            </GuestRoute>
+        ),
     },
     {
         path: '/register',
-        element: <RegisterPage />,
+        element: (
+            <GuestRoute>
+                <RegisterPage />
+            </GuestRoute>
+        ),
     },
     {
         path: '*',


### PR DESCRIPTION
## Summary
Add route protection so unauthenticated users cannot access private pages,
and authenticated users cannot revisit login or register.

## Related Issue
Closes #30

## Changes
- Created ProtectedRoute component — redirects to /login if not authenticated
- Created GuestRoute component — redirects to / if already authenticated
- Applied ProtectedRoute to the root / route
- Applied GuestRoute to /login and /register routes

## Testing
- Visiting / without a token redirects to /login
- Visiting /login or /register while authenticated redirects to /
- Refreshing the page while logged in keeps the user on the protected page
- Login flow still works end to end

## Checklist
- [x] This PR stays within the issue scope
- [x] No profile switcher implemented (that is #31)
- [x] No secrets committed