### PR TITLE
feat: implement Category entity and API

### DIFF
--- a/backend/src/main/java/com/learnova/learnova_backend/course/controller/CategoryController.java
+++ b/backend/src/main/java/com/learnova/learnova_backend/course/controller/CategoryController.java
@@ -1,0 +1,37 @@
+package com.learnova.learnova_backend.course.controller;
+
+import com.learnova.learnova_backend.course.dto.CategoryRequest;
+import com.learnova.learnova_backend.course.dto.CategoryResponse;
+import com.learnova.learnova_backend.course.service.CategoryService;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+@RestController
+@RequestMapping("/api/v1/categories")
+@RequiredArgsConstructor
+public class CategoryController {
+
+    private final CategoryService categoryService;
+
+    @PostMapping
+    @ResponseStatus(HttpStatus.CREATED)
+    @PreAuthorize("hasRole('ADMIN')")
+    public CategoryResponse createCategory(@Valid @RequestBody CategoryRequest request) {
+        return categoryService.createCategory(request);
+    }
+
+    @GetMapping
+    public List<CategoryResponse> getAllCategories() {
+        return categoryService.getAllCategories();
+    }
+
+    @GetMapping("/{id}")
+    public CategoryResponse getCategoryById(@PathVariable Long id) {
+        return categoryService.getCategoryById(id);
+    }
+}

--- a/backend/src/main/java/com/learnova/learnova_backend/course/dto/CategoryRequest.java
+++ b/backend/src/main/java/com/learnova/learnova_backend/course/dto/CategoryRequest.java
@@ -1,0 +1,14 @@
+package com.learnova.learnova_backend.course.dto;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
+
+public record CategoryRequest(
+
+        @NotBlank(message = "Category name is required")
+        @Size(max = 100, message = "Category name must not exceed 100 characters")
+        String name,
+
+        @Size(max = 500, message = "Description must not exceed 500 characters")
+        String description
+) {}

--- a/backend/src/main/java/com/learnova/learnova_backend/course/dto/CategoryResponse.java
+++ b/backend/src/main/java/com/learnova/learnova_backend/course/dto/CategoryResponse.java
@@ -1,0 +1,10 @@
+package com.learnova.learnova_backend.course.dto;
+
+import java.time.Instant;
+
+public record CategoryResponse(
+        Long id,
+        String name,
+        String description,
+        Instant createdAt
+) {}

--- a/backend/src/main/java/com/learnova/learnova_backend/course/entity/Category.java
+++ b/backend/src/main/java/com/learnova/learnova_backend/course/entity/Category.java
@@ -1,0 +1,49 @@
+package com.learnova.learnova_backend.course.entity;
+
+import jakarta.persistence.*;
+import lombok.*;
+
+import java.time.Instant;
+
+@Entity
+@Table(
+        name = "categories",
+        uniqueConstraints = {
+                @UniqueConstraint(name = "uk_categories_name", columnNames = "name")
+        }
+)
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class Category {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(nullable = false, length = 100)
+    private String name;
+
+    @Column(length = 500)
+    private String description;
+
+    @Column(name = "created_at", nullable = false, updatable = false)
+    private Instant createdAt;
+
+    @Column(name = "updated_at", nullable = false)
+    private Instant updatedAt;
+
+    @PrePersist
+    void onCreate() {
+        Instant now = Instant.now();
+        this.createdAt = now;
+        this.updatedAt = now;
+    }
+
+    @PreUpdate
+    void onUpdate() {
+        this.updatedAt = Instant.now();
+    }
+}

--- a/backend/src/main/java/com/learnova/learnova_backend/course/repository/CategoryRepository.java
+++ b/backend/src/main/java/com/learnova/learnova_backend/course/repository/CategoryRepository.java
@@ -1,0 +1,9 @@
+package com.learnova.learnova_backend.course.repository;
+
+import com.learnova.learnova_backend.course.entity.Category;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface CategoryRepository extends JpaRepository<Category, Long> {
+
+    boolean existsByNameIgnoreCase(String name);
+}

--- a/backend/src/main/java/com/learnova/learnova_backend/course/service/CategoryService.java
+++ b/backend/src/main/java/com/learnova/learnova_backend/course/service/CategoryService.java
@@ -1,0 +1,66 @@
+package com.learnova.learnova_backend.course.service;
+
+import com.learnova.learnova_backend.course.dto.CategoryRequest;
+import com.learnova.learnova_backend.course.dto.CategoryResponse;
+import com.learnova.learnova_backend.course.entity.Category;
+import com.learnova.learnova_backend.course.repository.CategoryRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.server.ResponseStatusException;
+
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+public class CategoryService {
+
+    private final CategoryRepository categoryRepository;
+
+    @Transactional
+    public CategoryResponse createCategory(CategoryRequest request) {
+        String normalizedName = request.name().trim();
+
+        if (categoryRepository.existsByNameIgnoreCase(normalizedName)) {
+            throw new ResponseStatusException(
+                    HttpStatus.CONFLICT,
+                    "Category with this name already exists"
+            );
+        }
+
+        Category category = Category.builder()
+                .name(normalizedName)
+                .description(request.description() != null ? request.description().trim() : null)
+                .build();
+
+        return toResponse(categoryRepository.save(category));
+    }
+
+    @Transactional(readOnly = true)
+    public List<CategoryResponse> getAllCategories() {
+        return categoryRepository.findAll()
+                .stream()
+                .map(this::toResponse)
+                .toList();
+    }
+
+    @Transactional(readOnly = true)
+    public CategoryResponse getCategoryById(Long id) {
+        return categoryRepository.findById(id)
+                .map(this::toResponse)
+                .orElseThrow(() -> new ResponseStatusException(
+                        HttpStatus.NOT_FOUND,
+                        "Category not found"
+                ));
+    }
+
+    private CategoryResponse toResponse(Category category) {
+        return new CategoryResponse(
+                category.getId(),
+                category.getName(),
+                category.getDescription(),
+                category.getCreatedAt()
+        );
+    }
+}

--- a/backend/src/main/java/com/learnova/learnova_backend/security/SecurityConfig.java
+++ b/backend/src/main/java/com/learnova/learnova_backend/security/SecurityConfig.java
@@ -20,10 +20,11 @@ import org.springframework.web.cors.CorsConfiguration;
 import org.springframework.web.cors.CorsConfigurationSource;
 import org.springframework.web.cors.UrlBasedCorsConfigurationSource;
 import java.util.List;
+import jakarta.servlet.http.HttpServletResponse;
 
 @Configuration
 @EnableWebSecurity
-@EnableMethodSecurity
+@EnableMethodSecurity(prePostEnabled = true)
 @RequiredArgsConstructor
 public class SecurityConfig {
 
@@ -38,6 +39,11 @@ public class SecurityConfig {
                 .cors(Customizer.withDefaults())
                 .sessionManagement(session ->
                         session.sessionCreationPolicy(SessionCreationPolicy.STATELESS)
+                )
+                .exceptionHandling(ex -> ex
+                        .authenticationEntryPoint((request, response, authException) ->
+                                response.sendError(HttpServletResponse.SC_UNAUTHORIZED, "Unauthorized")
+                        )
                 )
                 .authorizeHttpRequests(auth -> auth
                         .requestMatchers(HttpMethod.POST, "/api/v1/auth/register").permitAll()
@@ -76,10 +82,9 @@ public class SecurityConfig {
         configuration.setAllowedMethods(List.of("GET", "POST", "PUT", "PATCH", "DELETE", "OPTIONS"));
         configuration.setAllowedHeaders(List.of("*"));
         configuration.setAllowCredentials(true);
-        return source -> {
-            UrlBasedCorsConfigurationSource urlSource = new UrlBasedCorsConfigurationSource();
-            urlSource.registerCorsConfiguration("/**", configuration);
-            return urlSource.getCorsConfiguration(source);
-        };
+
+        UrlBasedCorsConfigurationSource source = new UrlBasedCorsConfigurationSource();
+        source.registerCorsConfiguration("/**", configuration);
+        return source;
     }
 }


### PR DESCRIPTION
## Summary
Implement the Category entity, repository, service, and REST API
as the first step of Phase 3 course management.

## Related Issue
Closes #33

## Changes
- Created Category entity with name, description, timestamps
- Created CategoryRepository with existsByNameIgnoreCase
- Created CategoryRequest and CategoryResponse DTOs
- Created CategoryService with create, getAll, getById
- Created CategoryController with POST (admin only), GET all, GET by id

## Testing
- POST /api/v1/categories requires ADMIN role
- Duplicate category name returns 409
- GET /api/v1/categories is public
- GET /api/v1/categories/{id} returns 404 for unknown id
- Existing tests still pass

## Checklist
- [x] This PR stays within the issue scope
- [x] No course entity yet (that is #34)
- [x] No secrets committed