### PR TITLE
feat: implement archive and deactivate logic with role-based access #38

### DIFF
--- a/backend/src/main/java/com/learnova/learnova_backend/course/controller/CourseController.java
+++ b/backend/src/main/java/com/learnova/learnova_backend/course/controller/CourseController.java
@@ -13,13 +13,15 @@ import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 
 @RestController
-@RequestMapping("/api/v1/instructor/courses")
+@RequestMapping("/api/v1")
 @RequiredArgsConstructor
 public class CourseController {
 
     private final CourseService courseService;
 
-    @PostMapping
+    // --- Instructor Endpoints ---
+
+    @PostMapping("/instructor/courses")
     @ResponseStatus(HttpStatus.CREATED)
     @PreAuthorize("hasRole('INSTRUCTOR')")
     public CourseResponse createCourse(
@@ -28,7 +30,7 @@ public class CourseController {
         return courseService.createCourse(currentUser, request);
     }
 
-    @PutMapping("/{id}")
+    @PutMapping("/instructor/courses/{id}")
     @PreAuthorize("hasRole('INSTRUCTOR')")
     public CourseResponse updateCourse(
             @PathVariable Long id,
@@ -37,11 +39,27 @@ public class CourseController {
         return courseService.updateCourse(id, currentUser, request);
     }
 
-    @PatchMapping("/{id}/publish")
+    @PatchMapping("/instructor/courses/{id}/publish")
     @PreAuthorize("hasRole('INSTRUCTOR')")
     public CourseResponse publishCourse(
             @PathVariable Long id,
             @AuthenticationPrincipal CustomUserDetails currentUser) {
         return courseService.publishCourse(id, currentUser);
+    }
+
+    @PatchMapping("/instructor/courses/{id}/archive")
+    @PreAuthorize("hasRole('INSTRUCTOR')")
+    public CourseResponse archiveCourse(
+            @PathVariable Long id,
+            @AuthenticationPrincipal CustomUserDetails currentUser) {
+        return courseService.archiveCourse(id, currentUser);
+    }
+
+    // --- Admin Endpoints ---
+
+    @PatchMapping("/admin/courses/{id}/deactivate")
+    @PreAuthorize("hasRole('ADMIN')")
+    public CourseResponse deactivateCourse(@PathVariable Long id) {
+        return courseService.deactivateCourse(id);
     }
 }

--- a/backend/src/main/java/com/learnova/learnova_backend/course/entity/CourseStatus.java
+++ b/backend/src/main/java/com/learnova/learnova_backend/course/entity/CourseStatus.java
@@ -3,5 +3,6 @@ package com.learnova.learnova_backend.course.entity;
 public enum CourseStatus {
     DRAFT,
     PUBLISHED,
-    ARCHIVED
+    ARCHIVED,
+    DEACTIVATED
 }

--- a/backend/src/main/java/com/learnova/learnova_backend/course/service/CourseService.java
+++ b/backend/src/main/java/com/learnova/learnova_backend/course/service/CourseService.java
@@ -35,21 +35,18 @@ public class CourseService {
                 InstructorProfile instructorProfile = getInstructorProfile(currentUser.getId());
 
                 if (instructorProfile.getApprovalStatus() != InstructorApprovalStatus.APPROVED) {
-                        throw new ResponseStatusException(
-                                        HttpStatus.FORBIDDEN,
+                        throw new ResponseStatusException(HttpStatus.FORBIDDEN,
                                         "Your instructor profile is not approved yet");
                 }
 
-                if (courseRepository.existsByTitleIgnoreCaseAndInstructorProfileId(
-                                request.title().trim(), instructorProfile.getId())) {
-                        throw new ResponseStatusException(
-                                        HttpStatus.CONFLICT,
+                if (courseRepository.existsByTitleIgnoreCaseAndInstructorProfileId(request.title().trim(),
+                                instructorProfile.getId())) {
+                        throw new ResponseStatusException(HttpStatus.CONFLICT,
                                         "You already have a course with this title");
                 }
 
                 var category = categoryRepository.findById(request.categoryId())
-                                .orElseThrow(() -> new ResponseStatusException(
-                                                HttpStatus.NOT_FOUND,
+                                .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND,
                                                 "Category not found"));
 
                 Course course = Course.builder()
@@ -71,8 +68,7 @@ public class CourseService {
                 validateCourseOwnership(course, currentUser);
 
                 var category = categoryRepository.findById(request.categoryId())
-                                .orElseThrow(() -> new ResponseStatusException(
-                                                HttpStatus.NOT_FOUND,
+                                .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND,
                                                 "Category not found"));
 
                 course.setTitle(request.title().trim());
@@ -89,13 +85,11 @@ public class CourseService {
                 Course course = findCourseById(courseId);
                 validateCourseOwnership(course, currentUser);
 
-                // Ensure instructor is still approved
                 if (course.getInstructorProfile().getApprovalStatus() != InstructorApprovalStatus.APPROVED) {
                         throw new ResponseStatusException(HttpStatus.FORBIDDEN,
                                         "Instructor must be approved to publish courses");
                 }
 
-                // Validate Minimum Publishing Requirements
                 if (course.getDescription() == null || course.getDescription().isBlank()) {
                         throw new ResponseStatusException(HttpStatus.BAD_REQUEST,
                                         "Course must have a description before publishing");
@@ -119,25 +113,37 @@ public class CourseService {
                 return toResponse(courseRepository.save(course));
         }
 
+        @Transactional
+        public CourseResponse archiveCourse(Long courseId, CustomUserDetails currentUser) {
+                Course course = findCourseById(courseId);
+                validateCourseOwnership(course, currentUser);
+                course.setStatus(CourseStatus.ARCHIVED);
+                return toResponse(courseRepository.save(course));
+        }
+
+        @Transactional
+        public CourseResponse deactivateCourse(Long courseId) {
+                Course course = findCourseById(courseId);
+                course.setStatus(CourseStatus.DEACTIVATED);
+                return toResponse(courseRepository.save(course));
+        }
+
         private Course findCourseById(Long courseId) {
                 return courseRepository.findById(courseId)
-                                .orElseThrow(() -> new ResponseStatusException(
-                                                HttpStatus.NOT_FOUND,
+                                .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND,
                                                 "Course not found"));
         }
 
         private void validateCourseOwnership(Course course, CustomUserDetails currentUser) {
                 if (!course.getInstructorProfile().getUser().getId().equals(currentUser.getId())) {
-                        throw new ResponseStatusException(
-                                        HttpStatus.FORBIDDEN,
+                        throw new ResponseStatusException(HttpStatus.FORBIDDEN,
                                         "You do not have permission to modify this course");
                 }
         }
 
         private InstructorProfile getInstructorProfile(Long userId) {
                 return instructorProfileRepository.findByUserId(userId)
-                                .orElseThrow(() -> new ResponseStatusException(
-                                                HttpStatus.FORBIDDEN,
+                                .orElseThrow(() -> new ResponseStatusException(HttpStatus.FORBIDDEN,
                                                 "Instructor profile not found"));
         }
 


### PR DESCRIPTION
Implemented non-destructive removal of courses from public visibility via Archiving (Instructors) and Deactivation (Admins).

Changes:
  State Management: Added ARCHIVED and DEACTIVATED transitions in the CourseService.

Security:
  archiveCourse requires the INSTRUCTOR role and ownership of the course.
  
  deactivateCourse requires the ADMIN role.
  
  REST Compliance: Used PATCH requests as these are partial state updates.
  
  Closes #38 