### PR TITLE
feat: implement lesson management with multimedia support #41

### DIFF
--- a/backend/src/main/java/com/learnova/learnova_backend/course/controller/LessonController.java
+++ b/backend/src/main/java/com/learnova/learnova_backend/course/controller/LessonController.java
@@ -1,0 +1,60 @@
+package com.learnova.learnova_backend.course.controller;
+
+import com.learnova.learnova_backend.course.dto.LessonRequest;
+import com.learnova.learnova_backend.course.dto.LessonResponse;
+import com.learnova.learnova_backend.course.service.LessonService;
+import com.learnova.learnova_backend.security.CustomUserDetails;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+@RestController
+@RequestMapping("/api/v1/instructor/courses/{courseId}/sections/{sectionId}/lessons")
+@RequiredArgsConstructor
+public class LessonController {
+
+    private final LessonService lessonService;
+
+    @GetMapping
+    public List<LessonResponse> getLessons(@PathVariable Long sectionId) {
+        return lessonService.getSectionLessons(sectionId);
+    }
+
+    @PostMapping
+    @ResponseStatus(HttpStatus.CREATED)
+    @PreAuthorize("hasRole('INSTRUCTOR')")
+    public LessonResponse createLesson(
+            @PathVariable Long courseId,
+            @PathVariable Long sectionId,
+            @AuthenticationPrincipal CustomUserDetails currentUser,
+            @Valid @RequestBody LessonRequest request) {
+        return lessonService.createLesson(courseId, sectionId, currentUser.getId(), request);
+    }
+
+    @PutMapping("/{lessonId}")
+    @PreAuthorize("hasRole('INSTRUCTOR')")
+    public LessonResponse updateLesson(
+            @PathVariable Long courseId,
+            @PathVariable Long sectionId,
+            @PathVariable Long lessonId,
+            @AuthenticationPrincipal CustomUserDetails currentUser,
+            @Valid @RequestBody LessonRequest request) {
+        return lessonService.updateLesson(courseId, sectionId, lessonId, currentUser.getId(), request);
+    }
+
+    @DeleteMapping("/{lessonId}")
+    @ResponseStatus(HttpStatus.NO_CONTENT)
+    @PreAuthorize("hasRole('INSTRUCTOR')")
+    public void deleteLesson(
+            @PathVariable Long courseId,
+            @PathVariable Long sectionId,
+            @PathVariable Long lessonId,
+            @AuthenticationPrincipal CustomUserDetails currentUser) {
+        lessonService.deleteLesson(courseId, sectionId, lessonId, currentUser.getId());
+    }
+}

--- a/backend/src/main/java/com/learnova/learnova_backend/course/dto/LessonRequest.java
+++ b/backend/src/main/java/com/learnova/learnova_backend/course/dto/LessonRequest.java
@@ -1,0 +1,14 @@
+package com.learnova.learnova_backend.course.dto;
+
+import com.learnova.learnova_backend.course.entity.LessonContentType;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.PositiveOrZero;
+
+public record LessonRequest(
+        @NotBlank(message = "Title is required") String title,
+        @NotNull(message = "Position is required") @PositiveOrZero Integer position,
+        @NotNull(message = "Content type is required") LessonContentType contentType,
+        String contentUrl,
+        String textContent) {
+}

--- a/backend/src/main/java/com/learnova/learnova_backend/course/dto/LessonResponse.java
+++ b/backend/src/main/java/com/learnova/learnova_backend/course/dto/LessonResponse.java
@@ -1,0 +1,13 @@
+package com.learnova.learnova_backend.course.dto;
+
+import com.learnova.learnova_backend.course.entity.LessonContentType;
+
+public record LessonResponse(
+        Long id,
+        String title,
+        Integer position,
+        LessonContentType contentType,
+        String contentUrl,
+        String textContent,
+        Long sectionId) {
+}

--- a/backend/src/main/java/com/learnova/learnova_backend/course/entity/Lesson.java
+++ b/backend/src/main/java/com/learnova/learnova_backend/course/entity/Lesson.java
@@ -18,7 +18,18 @@ public class Lesson {
     @Column(nullable = false)
     private String title;
 
-    private String content;
+    @Column(nullable = false)
+    private Integer position;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false)
+    private LessonContentType contentType;
+
+    @Column(columnDefinition = "TEXT")
+    private String contentUrl; // URL for Video/PDF/Link/Attachment
+
+    @Column(columnDefinition = "TEXT")
+    private String textContent; // For TEXT type content
 
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "section_id", nullable = false)

--- a/backend/src/main/java/com/learnova/learnova_backend/course/entity/LessonContentType.java
+++ b/backend/src/main/java/com/learnova/learnova_backend/course/entity/LessonContentType.java
@@ -1,0 +1,9 @@
+package com.learnova.learnova_backend.course.entity;
+
+public enum LessonContentType {
+    VIDEO,
+    PDF,
+    TEXT,
+    EXTERNAL_LINK,
+    ATTACHMENT
+}

--- a/backend/src/main/java/com/learnova/learnova_backend/course/repository/LessonRepository.java
+++ b/backend/src/main/java/com/learnova/learnova_backend/course/repository/LessonRepository.java
@@ -1,0 +1,9 @@
+package com.learnova.learnova_backend.course.repository;
+
+import com.learnova.learnova_backend.course.entity.Lesson;
+import org.springframework.data.jpa.repository.JpaRepository;
+import java.util.List;
+
+public interface LessonRepository extends JpaRepository<Lesson, Long> {
+    List<Lesson> findBySectionIdOrderByPositionAsc(Long sectionId);
+}

--- a/backend/src/main/java/com/learnova/learnova_backend/course/service/LessonService.java
+++ b/backend/src/main/java/com/learnova/learnova_backend/course/service/LessonService.java
@@ -1,0 +1,107 @@
+package com.learnova.learnova_backend.course.service;
+
+import com.learnova.learnova_backend.course.dto.LessonRequest;
+import com.learnova.learnova_backend.course.dto.LessonResponse;
+import com.learnova.learnova_backend.course.entity.Lesson;
+import com.learnova.learnova_backend.course.entity.Section;
+import com.learnova.learnova_backend.course.repository.LessonRepository;
+import com.learnova.learnova_backend.course.repository.SectionRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.server.ResponseStatusException;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Service
+@RequiredArgsConstructor
+public class LessonService {
+
+    private final LessonRepository lessonRepository;
+    private final SectionRepository sectionRepository;
+    private final CourseService courseService;
+
+    @Transactional(readOnly = true)
+    public List<LessonResponse> getSectionLessons(Long sectionId) {
+        return lessonRepository.findBySectionIdOrderByPositionAsc(sectionId)
+                .stream()
+                .map(this::toResponse)
+                .collect(Collectors.toList());
+    }
+
+    @Transactional
+    public LessonResponse createLesson(Long courseId, Long sectionId, Long userId, LessonRequest request) {
+        Section section = validateSectionOwnership(courseId, sectionId, userId);
+
+        Lesson lesson = Lesson.builder()
+                .title(request.title().trim())
+                .position(request.position())
+                .contentType(request.contentType())
+                .contentUrl(request.contentUrl())
+                .textContent(request.textContent())
+                .section(section)
+                .build();
+
+        return toResponse(lessonRepository.save(lesson));
+    }
+
+    @Transactional
+    public LessonResponse updateLesson(Long courseId, Long sectionId, Long lessonId, Long userId,
+            LessonRequest request) {
+        validateSectionOwnership(courseId, sectionId, userId);
+        Lesson lesson = findLessonAndValidateSection(lessonId, sectionId);
+
+        lesson.setTitle(request.title().trim());
+        lesson.setPosition(request.position());
+        lesson.setContentType(request.contentType());
+        lesson.setContentUrl(request.contentUrl());
+        lesson.setTextContent(request.textContent());
+
+        return toResponse(lessonRepository.save(lesson));
+    }
+
+    @Transactional
+    public void deleteLesson(Long courseId, Long sectionId, Long lessonId, Long userId) {
+        validateSectionOwnership(courseId, sectionId, userId);
+        Lesson lesson = findLessonAndValidateSection(lessonId, sectionId);
+        lessonRepository.delete(lesson);
+    }
+
+    private Section validateSectionOwnership(Long courseId, Long sectionId, Long userId) {
+        // First, verify the user owns the course
+        courseService.validateAndGetCourseOwnership(courseId, userId);
+
+        // Then, verify the section belongs to that course
+        Section section = sectionRepository.findById(sectionId)
+                .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND, "Section not found"));
+
+        if (!section.getCourse().getId().equals(courseId)) {
+            throw new ResponseStatusException(HttpStatus.BAD_REQUEST,
+                    "Section does not belong to the specified course");
+        }
+        return section;
+    }
+
+    private Lesson findLessonAndValidateSection(Long lessonId, Long sectionId) {
+        Lesson lesson = lessonRepository.findById(lessonId)
+                .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND, "Lesson not found"));
+
+        if (!lesson.getSection().getId().equals(sectionId)) {
+            throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "Lesson does not belong to this section");
+        }
+        return lesson;
+    }
+
+    private LessonResponse toResponse(Lesson lesson) {
+        return new LessonResponse(
+                lesson.getId(),
+                lesson.getTitle(),
+                lesson.getPosition(),
+                lesson.getContentType(),
+                lesson.getContentUrl(),
+                lesson.getTextContent(),
+                lesson.getSection().getId());
+    }
+}

--- a/backend/src/main/java/com/learnova/learnova_backend/course/service/SectionService.java
+++ b/backend/src/main/java/com/learnova/learnova_backend/course/service/SectionService.java
@@ -1,0 +1,89 @@
+package com.learnova.learnova_backend.course.service;
+
+import com.learnova.learnova_backend.course.dto.SectionRequest;
+import com.learnova.learnova_backend.course.dto.SectionResponse;
+import com.learnova.learnova_backend.course.entity.Course;
+import com.learnova.learnova_backend.course.entity.Section;
+import com.learnova.learnova_backend.course.repository.SectionRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.server.ResponseStatusException;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Service
+@RequiredArgsConstructor
+public class SectionService {
+
+    private final SectionRepository sectionRepository;
+    private final CourseService courseService;
+
+    @Transactional(readOnly = true)
+    public List<SectionResponse> getCourseSections(Long courseId) {
+        // Anyone can list sections (public or instructor), 
+        // but typically you'd just return the ordered list.
+        return sectionRepository.findByCourseIdOrderByPositionAsc(courseId)
+                .stream()
+                .map(this::toResponse)
+                .collect(Collectors.toList());
+    }
+
+    @Transactional
+    public SectionResponse createSection(Long courseId, Long userId, SectionRequest request) {
+        Course course = courseService.validateAndGetCourseOwnership(courseId, userId);
+
+        Section section = Section.builder()
+                .title(request.title().trim())
+                .position(request.position())
+                .course(course)
+                .build();
+
+        return toResponse(sectionRepository.save(section));
+    }
+
+    @Transactional
+    public SectionResponse updateSection(Long courseId, Long sectionId, Long userId, SectionRequest request) {
+        courseService.validateAndGetCourseOwnership(courseId, userId);
+
+        Section section = findSectionById(sectionId);
+        
+        // Ensure section belongs to the validated course
+        if (!section.getCourse().getId().equals(courseId)) {
+            throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "Section does not belong to this course");
+        }
+
+        section.setTitle(request.title().trim());
+        section.setPosition(request.position());
+
+        return toResponse(sectionRepository.save(section));
+    }
+
+    @Transactional
+    public void deleteSection(Long courseId, Long sectionId, Long userId) {
+        courseService.validateAndGetCourseOwnership(courseId, userId);
+        
+        Section section = findSectionById(sectionId);
+        if (!section.getCourse().getId().equals(courseId)) {
+            throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "Section does not belong to this course");
+        }
+
+        sectionRepository.delete(section);
+    }
+
+    private Section findSectionById(Long id) {
+        return sectionRepository.findById(id)
+                .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND, "Section not found"));
+    }
+
+    private SectionResponse toResponse(Section section) {
+        return new SectionResponse(
+                section.getId(),
+                section.getTitle(),
+                section.getPosition(),
+                section.getCourse().getId()
+        );
+    }
+}


### PR DESCRIPTION
Added the final layer of course content management by implementing Lessons. Instructors can now add multimedia content to their sections.

Changes:
    Entity & Enum: Created Lesson with support for LessonContentType (VIDEO, PDF, etc.).
    
    Security: Implemented multi-level ownership validation (User -> Course -> Section -> Lesson).
    
    Ordering: Lessons are retrieved ordered by the position field.
    
    Flexibility: Added fields for both contentUrl (for external files) and textContent (for direct reading).
    
Closes #41 