### PR TITLE
feat: add instructor course listing with pagination and stats #43

### DIFF
--- a/backend/src/main/java/com/learnova/learnova_backend/course/controller/CourseController.java
+++ b/backend/src/main/java/com/learnova/learnova_backend/course/controller/CourseController.java
@@ -12,6 +12,10 @@ import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 import org.springframework.web.multipart.MultipartFile;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.web.PageableDefault;
+import org.springframework.data.domain.Sort;
 
 @RestController
 @RequestMapping("/api/v1")
@@ -21,6 +25,14 @@ public class CourseController {
     private final CourseService courseService;
 
     // --- Instructor Endpoints ---
+
+    @GetMapping("/instructor/courses")
+    @PreAuthorize("hasRole('INSTRUCTOR')")
+    public Page<CourseResponse> getMyCourses(
+            @AuthenticationPrincipal CustomUserDetails currentUser,
+            @PageableDefault(size = 10, sort = "createdAt", direction = Sort.Direction.DESC) Pageable pageable) {
+        return courseService.getInstructorCourses(currentUser, pageable);
+    }
 
     @PostMapping("/instructor/courses")
     @ResponseStatus(HttpStatus.CREATED)

--- a/backend/src/main/java/com/learnova/learnova_backend/course/entity/Course.java
+++ b/backend/src/main/java/com/learnova/learnova_backend/course/entity/Course.java
@@ -5,6 +5,8 @@ import jakarta.persistence.*;
 import lombok.*;
 
 import java.time.Instant;
+import java.util.ArrayList;
+import java.util.List;
 
 @Entity
 @Table(name = "courses")
@@ -20,19 +22,11 @@ public class Course {
     private Long id;
 
     @ManyToOne(fetch = FetchType.LAZY, optional = false)
-    @JoinColumn(
-            name = "instructor_profile_id",
-            nullable = false,
-            foreignKey = @ForeignKey(name = "fk_courses_instructor_profile")
-    )
+    @JoinColumn(name = "instructor_profile_id", nullable = false, foreignKey = @ForeignKey(name = "fk_courses_instructor_profile"))
     private InstructorProfile instructorProfile;
 
     @ManyToOne(fetch = FetchType.LAZY, optional = false)
-    @JoinColumn(
-            name = "category_id",
-            nullable = false,
-            foreignKey = @ForeignKey(name = "fk_courses_category")
-    )
+    @JoinColumn(name = "category_id", nullable = false, foreignKey = @ForeignKey(name = "fk_courses_category"))
     private Category category;
 
     @Column(nullable = false, length = 200)
@@ -53,6 +47,11 @@ public class Course {
     @Column(nullable = false, length = 30)
     @Builder.Default
     private CourseStatus status = CourseStatus.DRAFT;
+
+    // --- Added Relationship to fix the compilation error ---
+    @OneToMany(mappedBy = "course", cascade = CascadeType.ALL, orphanRemoval = true)
+    @Builder.Default
+    private List<Section> sections = new ArrayList<>();
 
     @Column(name = "created_at", nullable = false, updatable = false)
     private Instant createdAt;

--- a/backend/src/main/java/com/learnova/learnova_backend/course/repository/CourseRepository.java
+++ b/backend/src/main/java/com/learnova/learnova_backend/course/repository/CourseRepository.java
@@ -2,13 +2,16 @@ package com.learnova.learnova_backend.course.repository;
 
 import com.learnova.learnova_backend.course.entity.Course;
 import com.learnova.learnova_backend.course.entity.CourseStatus;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+
+import org.springframework.data.domain.Page;
 
 import java.util.List;
 
 public interface CourseRepository extends JpaRepository<Course, Long> {
 
-    List<Course> findByInstructorProfileId(Long instructorProfileId);
+    Page<Course> findByInstructorProfileId(Long instructorProfileId, Pageable pageable);
 
     List<Course> findByStatus(CourseStatus status);
 

--- a/backend/src/main/java/com/learnova/learnova_backend/course/service/CourseService.java
+++ b/backend/src/main/java/com/learnova/learnova_backend/course/service/CourseService.java
@@ -20,6 +20,8 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.multipart.MultipartFile;
 import org.springframework.web.server.ResponseStatusException;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 
 import java.util.List;
 
@@ -36,7 +38,6 @@ public class CourseService {
         /**
          * CORE OWNERSHIP UTILITY
          * Validates if the authenticated user is the owner of the course.
-         * This is the "Utility method" required by Acceptance Criteria.
          */
         public Course validateAndGetCourseOwnership(Long courseId, Long userId) {
                 Course course = courseRepository.findById(courseId)
@@ -49,6 +50,14 @@ public class CourseService {
                                         "Access Denied: You do not own this course");
                 }
                 return course;
+        }
+
+        // --- THIS METHOD RESOLVES THE CONTROLLER ERROR ---
+        @Transactional(readOnly = true)
+        public Page<CourseResponse> getInstructorCourses(CustomUserDetails currentUser, Pageable pageable) {
+                InstructorProfile instructor = getInstructorProfile(currentUser.getId());
+                return courseRepository.findByInstructorProfileId(instructor.getId(), pageable)
+                                .map(this::toResponse);
         }
 
         @Transactional
@@ -78,6 +87,7 @@ public class CourseService {
                                 .level(request.level())
                                 .thumbnailUrl(request.thumbnailUrl() != null ? request.thumbnailUrl().trim() : null)
                                 .status(CourseStatus.DRAFT)
+                                // sections initialized automatically via Builder.Default in entity
                                 .build();
 
                 return toResponse(courseRepository.save(course));
@@ -85,7 +95,6 @@ public class CourseService {
 
         @Transactional
         public CourseResponse updateCourse(Long courseId, CustomUserDetails currentUser, CourseUpdateRequest request) {
-                // Ownership Check Applied
                 Course course = validateAndGetCourseOwnership(courseId, currentUser.getId());
 
                 var category = categoryRepository.findById(request.categoryId())
@@ -103,7 +112,6 @@ public class CourseService {
 
         @Transactional
         public CourseResponse publishCourse(Long courseId, CustomUserDetails currentUser) {
-                // Ownership Check Applied
                 Course course = validateAndGetCourseOwnership(courseId, currentUser.getId());
 
                 if (course.getInstructorProfile().getApprovalStatus() != InstructorApprovalStatus.APPROVED) {
@@ -111,7 +119,6 @@ public class CourseService {
                                         "Instructor must be approved to publish courses");
                 }
 
-                // Requirements check
                 validatePublishingRequirements(course);
 
                 course.setStatus(CourseStatus.PUBLISHED);
@@ -120,7 +127,6 @@ public class CourseService {
 
         @Transactional
         public CourseResponse archiveCourse(Long courseId, CustomUserDetails currentUser) {
-                // Ownership Check Applied
                 Course course = validateAndGetCourseOwnership(courseId, currentUser.getId());
                 course.setStatus(CourseStatus.ARCHIVED);
                 return toResponse(courseRepository.save(course));
@@ -130,7 +136,6 @@ public class CourseService {
         public String uploadThumbnail(Long courseId, CustomUserDetails currentUser, MultipartFile file) {
                 Course course = validateAndGetCourseOwnership(courseId, currentUser.getId());
 
-                // Delete old thumbnail if it exists
                 if (course.getThumbnailUrl() != null) {
                         fileStorageService.deleteFile(course.getThumbnailUrl());
                 }
@@ -143,7 +148,6 @@ public class CourseService {
 
         @Transactional
         public CourseResponse deactivateCourse(Long courseId) {
-                // NO ownership check here because this is an ADMIN operation
                 Course course = courseRepository.findById(courseId)
                                 .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND,
                                                 "Course not found"));
@@ -178,6 +182,12 @@ public class CourseService {
         }
 
         public CourseResponse toResponse(Course course) {
+                long sectionCount = course.getSections() != null ? course.getSections().size() : 0;
+                long lessonCount = course.getSections() != null ? course.getSections().stream()
+                                .filter(section -> section.getLessons() != null)
+                                .mapToLong(section -> section.getLessons().size())
+                                .sum() : 0;
+
                 return new CourseResponse(
                                 course.getId(),
                                 course.getTitle(),
@@ -189,6 +199,8 @@ public class CourseService {
                                 course.getCategory().getName(),
                                 course.getInstructorProfile().getId(),
                                 course.getInstructorProfile().getUser().getFullName(),
+                                sectionCount,
+                                lessonCount,
                                 course.getCreatedAt(),
                                 course.getUpdatedAt());
         }

--- a/backend/src/main/java/com/learnova/learnova_backend/course/service/LessonService.java
+++ b/backend/src/main/java/com/learnova/learnova_backend/course/service/LessonService.java
@@ -11,7 +11,6 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
-import org.springframework.web.bind.annotation.*;
 import org.springframework.web.multipart.MultipartFile;
 import org.springframework.web.server.ResponseStatusException;
 
@@ -70,12 +69,12 @@ public class LessonService {
     public void deleteLesson(Long courseId, Long sectionId, Long lessonId, Long userId) {
         validateSectionOwnership(courseId, sectionId, userId);
         Lesson lesson = findLessonAndValidateSection(lessonId, sectionId);
-        
+
         // Delete associated file if it exists
         if (lesson.getContentUrl() != null) {
             fileStorageService.deleteFile(lesson.getContentUrl());
         }
-        
+
         lessonRepository.delete(lesson);
     }
 


### PR DESCRIPTION
Created a paginated management API for instructors to view their course portfolio with high-level statistics (section and lesson counts).

Changes:

    DTO Enhancement: Added sectionCount and lessonCount to CourseResponse.
    
    Pagination Support: Updated CourseRepository and CourseController to support Spring Data Pageable.
    
    Security: Strict INSTRUCTOR role check and automatic filtering by the authenticated user's profile ID.
    
    Sorting: Default sorting set to most recently created courses first.
    
Closes #43 