### PR TITLE
feat: expose public catalog browsing with secure curriculum previews #44

### DIFF
--- a/backend/src/main/java/com/learnova/learnova_backend/course/controller/CourseController.java
+++ b/backend/src/main/java/com/learnova/learnova_backend/course/controller/CourseController.java
@@ -3,6 +3,7 @@ package com.learnova.learnova_backend.course.controller;
 import com.learnova.learnova_backend.course.dto.CourseRequest;
 import com.learnova.learnova_backend.course.dto.CourseResponse;
 import com.learnova.learnova_backend.course.dto.CourseUpdateRequest;
+import com.learnova.learnova_backend.course.dto.PublicCourseDetailResponse;
 import com.learnova.learnova_backend.course.service.CourseService;
 import com.learnova.learnova_backend.security.CustomUserDetails;
 import jakarta.validation.Valid;
@@ -23,6 +24,19 @@ import org.springframework.data.domain.Sort;
 public class CourseController {
 
     private final CourseService courseService;
+
+    // --- Public Browsing Endpoints ---
+
+    @GetMapping("/courses")
+    public Page<CourseResponse> getPublicCourses(
+            @PageableDefault(size = 12, sort = "createdAt", direction = Sort.Direction.DESC) Pageable pageable) {
+        return courseService.getPublicCourses(pageable);
+    }
+
+    @GetMapping("/courses/{id}")
+    public PublicCourseDetailResponse getPublicCourseDetail(@PathVariable Long id) {
+        return courseService.getPublicCourseDetail(id);
+    }
 
     // --- Instructor Endpoints ---
 

--- a/backend/src/main/java/com/learnova/learnova_backend/course/dto/CourseResponse.java
+++ b/backend/src/main/java/com/learnova/learnova_backend/course/dto/CourseResponse.java
@@ -6,16 +6,18 @@ import com.learnova.learnova_backend.course.entity.CourseStatus;
 import java.time.Instant;
 
 public record CourseResponse(
-        Long id,
-        String title,
-        String description,
-        CourseLevel level,
-        CourseStatus status,
-        String thumbnailUrl,
-        Long categoryId,
-        String categoryName,
-        Long instructorProfileId,
-        String instructorName,
-        Instant createdAt,
-        Instant updatedAt
-) {}
+                Long id,
+                String title,
+                String description,
+                CourseLevel level,
+                CourseStatus status,
+                String thumbnailUrl,
+                Long categoryId,
+                String categoryName,
+                Long instructorProfileId,
+                String instructorName,
+                long sectionCount,
+                long lessonCount,
+                Instant createdAt,
+                Instant updatedAt) {
+}

--- a/backend/src/main/java/com/learnova/learnova_backend/course/dto/PublicCourseDetailResponse.java
+++ b/backend/src/main/java/com/learnova/learnova_backend/course/dto/PublicCourseDetailResponse.java
@@ -1,0 +1,16 @@
+package com.learnova.learnova_backend.course.dto;
+
+import com.learnova.learnova_backend.course.entity.CourseLevel;
+import java.util.List;
+
+public record PublicCourseDetailResponse(
+        Long id,
+        String title,
+        String description,
+        CourseLevel level,
+        String thumbnailUrl,
+        Long categoryId,
+        String categoryName,
+        String instructorName,
+        List<PublicSectionPreview> sections) {
+}

--- a/backend/src/main/java/com/learnova/learnova_backend/course/dto/PublicLessonPreview.java
+++ b/backend/src/main/java/com/learnova/learnova_backend/course/dto/PublicLessonPreview.java
@@ -1,0 +1,10 @@
+package com.learnova.learnova_backend.course.dto;
+
+import com.learnova.learnova_backend.course.entity.LessonContentType;
+
+public record PublicLessonPreview(
+        Long id,
+        String title,
+        Integer position,
+        LessonContentType contentType) {
+}

--- a/backend/src/main/java/com/learnova/learnova_backend/course/dto/PublicSectionPreview.java
+++ b/backend/src/main/java/com/learnova/learnova_backend/course/dto/PublicSectionPreview.java
@@ -1,0 +1,10 @@
+package com.learnova.learnova_backend.course.dto;
+
+import java.util.List;
+
+public record PublicSectionPreview(
+        Long id,
+        String title,
+        Integer position,
+        List<PublicLessonPreview> lessons) {
+}

--- a/backend/src/main/java/com/learnova/learnova_backend/course/repository/CourseRepository.java
+++ b/backend/src/main/java/com/learnova/learnova_backend/course/repository/CourseRepository.java
@@ -2,18 +2,20 @@ package com.learnova.learnova_backend.course.repository;
 
 import com.learnova.learnova_backend.course.entity.Course;
 import com.learnova.learnova_backend.course.entity.CourseStatus;
+import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
-
-import org.springframework.data.domain.Page;
-
 import java.util.List;
+import java.util.Optional;
 
 public interface CourseRepository extends JpaRepository<Course, Long> {
-
     Page<Course> findByInstructorProfileId(Long instructorProfileId, Pageable pageable);
 
-    List<Course> findByStatus(CourseStatus status);
+    // For Public Listing
+    Page<Course> findByStatus(CourseStatus status, Pageable pageable);
+
+    // For Public Detailed View validation
+    Optional<Course> findByIdAndStatus(Long id, CourseStatus status);
 
     List<Course> findByCategoryId(Long categoryId);
 

--- a/backend/src/main/java/com/learnova/learnova_backend/course/service/CourseService.java
+++ b/backend/src/main/java/com/learnova/learnova_backend/course/service/CourseService.java
@@ -1,8 +1,6 @@
 package com.learnova.learnova_backend.course.service;
 
-import com.learnova.learnova_backend.course.dto.CourseRequest;
-import com.learnova.learnova_backend.course.dto.CourseResponse;
-import com.learnova.learnova_backend.course.dto.CourseUpdateRequest;
+import com.learnova.learnova_backend.course.dto.*;
 import com.learnova.learnova_backend.course.entity.Course;
 import com.learnova.learnova_backend.course.entity.CourseStatus;
 import com.learnova.learnova_backend.course.entity.Section;
@@ -24,6 +22,7 @@ import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 
 import java.util.List;
+import java.util.stream.Collectors;
 
 @Service
 @RequiredArgsConstructor
@@ -35,10 +34,6 @@ public class CourseService {
         private final SectionRepository sectionRepository;
         private final FileStorageService fileStorageService;
 
-        /**
-         * CORE OWNERSHIP UTILITY
-         * Validates if the authenticated user is the owner of the course.
-         */
         public Course validateAndGetCourseOwnership(Long courseId, Long userId) {
                 Course course = courseRepository.findById(courseId)
                                 .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND,
@@ -52,13 +47,54 @@ public class CourseService {
                 return course;
         }
 
-        // --- THIS METHOD RESOLVES THE CONTROLLER ERROR ---
         @Transactional(readOnly = true)
         public Page<CourseResponse> getInstructorCourses(CustomUserDetails currentUser, Pageable pageable) {
                 InstructorProfile instructor = getInstructorProfile(currentUser.getId());
                 return courseRepository.findByInstructorProfileId(instructor.getId(), pageable)
                                 .map(this::toResponse);
         }
+
+        // --- NEW PUBLIC BROWSING METHODS ---
+
+        @Transactional(readOnly = true)
+        public Page<CourseResponse> getPublicCourses(Pageable pageable) {
+                return courseRepository.findByStatus(CourseStatus.PUBLISHED, pageable)
+                                .map(this::toResponse);
+        }
+
+        @Transactional(readOnly = true)
+        public PublicCourseDetailResponse getPublicCourseDetail(Long courseId) {
+                Course course = courseRepository.findByIdAndStatus(courseId, CourseStatus.PUBLISHED)
+                                .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND,
+                                                "Course not found or is not available publicly"));
+
+                List<PublicSectionPreview> sectionPreviews = course.getSections().stream()
+                                .map(section -> new PublicSectionPreview(
+                                                section.getId(),
+                                                section.getTitle(),
+                                                section.getPosition(),
+                                                section.getLessons().stream()
+                                                                .map(lesson -> new PublicLessonPreview(
+                                                                                lesson.getId(),
+                                                                                lesson.getTitle(),
+                                                                                lesson.getPosition(),
+                                                                                lesson.getContentType()))
+                                                                .collect(Collectors.toList())))
+                                .collect(Collectors.toList());
+
+                return new PublicCourseDetailResponse(
+                                course.getId(),
+                                course.getTitle(),
+                                course.getDescription(),
+                                course.getLevel(),
+                                course.getThumbnailUrl(),
+                                course.getCategory().getId(),
+                                course.getCategory().getName(),
+                                course.getInstructorProfile().getUser().getFullName(),
+                                sectionPreviews);
+        }
+
+        // --- EXISTING MUTATION METHODS ---
 
         @Transactional
         public CourseResponse createCourse(CustomUserDetails currentUser, CourseRequest request) {
@@ -87,7 +123,6 @@ public class CourseService {
                                 .level(request.level())
                                 .thumbnailUrl(request.thumbnailUrl() != null ? request.thumbnailUrl().trim() : null)
                                 .status(CourseStatus.DRAFT)
-                                // sections initialized automatically via Builder.Default in entity
                                 .build();
 
                 return toResponse(courseRepository.save(course));


### PR DESCRIPTION
Exposed read-only published courses data with a curriculum outline view for non-authenticated guests and landing pages.

Changes:

    Filtering Strictness: Explicit implementation of findByIdAndStatus ensuring draft or archived content throws a 404 Not Found.
    
    Anonymized DTO Structure: Created PublicCourseDetailResponse containing only titles, layout structure ordering, and asset media references (stripping underlying complete lesson contents/secrets).
    
    Pagination Defaults: Default configuration set to list batches of 12 published courses dynamically sorted chronologically.
    
Closes #44