### PR TITLE
feat: implement LessonProgress entity and repository infrastructure #57

### DIFF
--- a/backend/src/main/java/com/learnova/learnova_backend/course/entity/Lesson.java
+++ b/backend/src/main/java/com/learnova/learnova_backend/course/entity/Lesson.java
@@ -1,0 +1,21 @@
+package com.learnova.learnova_backend.course.entity;
+
+import jakarta.persistence.*;
+import lombok.*;
+
+@Entity
+@Table(name = "lessons")
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class Lesson {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(nullable = false)
+    private String title;
+}

--- a/backend/src/main/java/com/learnova/learnova_backend/course/entity/LessonProgress.java
+++ b/backend/src/main/java/com/learnova/learnova_backend/course/entity/LessonProgress.java
@@ -1,0 +1,49 @@
+package com.learnova.learnova_backend.course.entity;
+
+import com.learnova.learnova_backend.profile.entity.LearnerProfile;
+import jakarta.persistence.*;
+import lombok.*;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Table(name = "lesson_progress", uniqueConstraints = {
+        @UniqueConstraint(name = "uk_learner_lesson", columnNames = { "learner_profile_id", "lesson_id" })
+})
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class LessonProgress {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY, optional = false)
+    @JoinColumn(name = "learner_profile_id", nullable = false)
+    private LearnerProfile learnerProfile;
+
+    @ManyToOne(fetch = FetchType.LAZY, optional = false)
+    @JoinColumn(name = "lesson_id", nullable = false)
+    private Lesson lesson;
+
+    @Column(name = "is_completed", nullable = false)
+    private boolean isCompleted = false;
+
+    @Column(name = "last_position_seconds")
+    private Integer lastPositionSeconds; // Pour le tracking de lecture vidéo (optionnel)
+
+    @Column(name = "time_spent_seconds")
+    private Integer timeSpentSeconds; // Temps passé sur la leçon (optionnel)
+
+    @Column(name = "updated_at")
+    private LocalDateTime updatedAt;
+
+    @PrePersist
+    @PreUpdate
+    protected void onUpdate() {
+        this.updatedAt = LocalDateTime.now();
+    }
+}

--- a/backend/src/main/java/com/learnova/learnova_backend/course/repository/LessonProgressRepository.java
+++ b/backend/src/main/java/com/learnova/learnova_backend/course/repository/LessonProgressRepository.java
@@ -1,0 +1,19 @@
+package com.learnova.learnova_backend.course.repository;
+
+import com.learnova.learnova_backend.course.entity.LessonProgress;
+import com.learnova.learnova_backend.course.entity.Lesson;
+import com.learnova.learnova_backend.profile.entity.LearnerProfile;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.Optional;
+
+@Repository
+public interface LessonProgressRepository extends JpaRepository<LessonProgress, Long> {
+
+    // Récupérer la progression pour un apprenant et une leçon spécifique
+    Optional<LessonProgress> findByLearnerProfileAndLesson(LearnerProfile learnerProfile, Lesson lesson);
+
+    // Vérifier si un enregistrement de progression existe déjà
+    boolean existsByLearnerProfileAndLesson(LearnerProfile learnerProfile, Lesson lesson);
+}


### PR DESCRIPTION
## Technical Implementation Summary

### Domain Model Architecture
* Created the LessonProgress JPA entity mapping schema to track structural interaction tracking layers.
* Established a safe operational relationship mapping linking LessonProgress data records directly down to the new LearnerProfile context layer.
* Implemented a contextual target relationship reference pointing towards the Lesson entity module layout.
* Configured a hard data database constraint enforcing a structural UniqueConstraint criteria across learner_profile_id and lesson_id data properties to eliminate any vector for duplicate tracking rows.

### Learning Execution State Tracking
* Embedded an explicit isCompleted primitive state flag defaulted to false to handle course requirement verification.
* Provided flexible metadata auditing fields capturing lastPositionSeconds and timeSpentSeconds for runtime media consumption metrics capture.
* Added lifecycle hook listeners capturing automated updatedAt timestamp instances during entity state transitions.

### Repository Infrastructure Binding
* Created the LessonProgressRepository standard data interface abstraction extending JpaRepository boundaries.
* Declared targeted lookup contracts including findByLearnerProfileAndLesson to resolve atomic progression metrics cleanly.

---

## File Structural Changes
* New Domain Progress Track: backend/src/main/java/com/learnova/learnova_backend/course/entity/LessonProgress.java
* New Repository Data Layer: backend/src/main/java/com/learnova/learnova_backend/course/repository/LessonProgressRepository.java
* Temporary Target Skeleton Mapping: backend/src/main/java/com/learnova/learnova_backend/course/entity/Lesson.java

---

## Verification and Compilation Status
* Local Build Verification: Ran validation tests over the updated domain workspace through the standard maven wrapper build framework.
* Compilation Status: Achieved a clean 100% build success check across the backend module package structure with zero compilation regressions or model interface definition blocks.

Closes #57 