### PR TITLE
feat: implement quiz question and answer option granular CRUD management APIs #75

### DIFF
--- a/backend/src/main/java/com/learnova/learnova_backend/course/controller/InstructorQuizController.java
+++ b/backend/src/main/java/com/learnova/learnova_backend/course/controller/InstructorQuizController.java
@@ -1,5 +1,9 @@
 package com.learnova.learnova_backend.course.controller;
 
+import com.learnova.learnova_backend.course.dto.AnswerOptionRequest;
+import com.learnova.learnova_backend.course.dto.AnswerOptionResponse;
+import com.learnova.learnova_backend.course.dto.QuestionRequest;
+import com.learnova.learnova_backend.course.dto.QuestionResponse;
 import com.learnova.learnova_backend.course.dto.QuizRequest;
 import com.learnova.learnova_backend.course.dto.QuizResponse;
 import com.learnova.learnova_backend.course.dto.QuizUpdateRequest;
@@ -36,7 +40,7 @@ public class InstructorQuizController {
             @PathVariable Long quizId,
             @AuthenticationPrincipal CustomUserDetails currentUser,
             @Valid @RequestBody QuizUpdateRequest request) {
-        
+
         QuizResponse response = quizService.updateQuiz(currentUser, quizId, request);
         return ResponseEntity.ok(response);
     }
@@ -45,7 +49,7 @@ public class InstructorQuizController {
     public ResponseEntity<QuizResponse> publishQuiz(
             @PathVariable Long quizId,
             @AuthenticationPrincipal CustomUserDetails currentUser) {
-        
+
         QuizResponse response = quizService.publishQuiz(currentUser, quizId);
         return ResponseEntity.ok(response);
     }
@@ -54,8 +58,68 @@ public class InstructorQuizController {
     public ResponseEntity<QuizResponse> archiveQuiz(
             @PathVariable Long quizId,
             @AuthenticationPrincipal CustomUserDetails currentUser) {
-        
+
         QuizResponse response = quizService.archiveQuiz(currentUser, quizId);
         return ResponseEntity.ok(response);
+    }
+
+    // --- GESTION DES QUESTIONS ---
+
+    @PostMapping("/quizzes/{quizId}/questions")
+    public ResponseEntity<QuestionResponse> addQuestion(
+            @PathVariable Long quizId,
+            @AuthenticationPrincipal CustomUserDetails currentUser,
+            @Valid @RequestBody QuestionRequest request) {
+
+        return ResponseEntity.status(HttpStatus.CREATED)
+                .body(quizService.addQuestionToQuiz(currentUser, quizId, request));
+    }
+
+    @PutMapping("/questions/{questionId}")
+    public ResponseEntity<QuestionResponse> updateQuestion(
+            @PathVariable Long questionId,
+            @AuthenticationPrincipal CustomUserDetails currentUser,
+            @Valid @RequestBody QuestionRequest request) {
+
+        return ResponseEntity.ok(quizService.updateQuestion(currentUser, questionId, request));
+    }
+
+    @DeleteMapping("/questions/{questionId}")
+    public ResponseEntity<Void> deleteQuestion(
+            @PathVariable Long questionId,
+            @AuthenticationPrincipal CustomUserDetails currentUser) {
+
+        quizService.deleteQuestion(currentUser, questionId);
+        return ResponseEntity.noContent().build();
+    }
+
+    // --- GESTION DES OPTIONS DE RÉPONSE ---
+
+    @PostMapping("/questions/{questionId}/options")
+    public ResponseEntity<AnswerOptionResponse> addAnswerOption(
+            @PathVariable Long questionId,
+            @AuthenticationPrincipal CustomUserDetails currentUser,
+            @Valid @RequestBody AnswerOptionRequest request) {
+
+        return ResponseEntity.status(HttpStatus.CREATED)
+                .body(quizService.addOptionToQuestion(currentUser, questionId, request));
+    }
+
+    @PutMapping("/options/{optionId}")
+    public ResponseEntity<AnswerOptionResponse> updateAnswerOption(
+            @PathVariable Long optionId,
+            @AuthenticationPrincipal CustomUserDetails currentUser,
+            @Valid @RequestBody AnswerOptionRequest request) {
+
+        return ResponseEntity.ok(quizService.updateAnswerOption(currentUser, optionId, request));
+    }
+
+    @DeleteMapping("/options/{optionId}")
+    public ResponseEntity<Void> deleteAnswerOption(
+            @PathVariable Long optionId,
+            @AuthenticationPrincipal CustomUserDetails currentUser) {
+
+        quizService.deleteAnswerOption(currentUser, optionId);
+        return ResponseEntity.noContent().build();
     }
 }

--- a/backend/src/main/java/com/learnova/learnova_backend/course/dto/AnswerOptionRequest.java
+++ b/backend/src/main/java/com/learnova/learnova_backend/course/dto/AnswerOptionRequest.java
@@ -1,0 +1,10 @@
+package com.learnova.learnova_backend.course.dto;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+
+public record AnswerOptionRequest(
+        @NotBlank(message = "Option text cannot be blank") String optionText,
+
+        @NotNull(message = "You must explicitly specify if this answer option is correct") Boolean isCorrect) {
+}

--- a/backend/src/main/java/com/learnova/learnova_backend/course/dto/AnswerOptionResponse.java
+++ b/backend/src/main/java/com/learnova/learnova_backend/course/dto/AnswerOptionResponse.java
@@ -1,0 +1,7 @@
+package com.learnova.learnova_backend.course.dto;
+
+public record AnswerOptionResponse(
+        Long id,
+        String optionText,
+        Boolean isCorrect) {
+}

--- a/backend/src/main/java/com/learnova/learnova_backend/course/dto/QuestionRequest.java
+++ b/backend/src/main/java/com/learnova/learnova_backend/course/dto/QuestionRequest.java
@@ -1,0 +1,14 @@
+package com.learnova.learnova_backend.course.dto;
+
+import com.learnova.learnova_backend.course.entity.QuestionType;
+import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+
+public record QuestionRequest(
+        @NotBlank(message = "Question content cannot be blank") String content,
+
+        @NotNull(message = "Question points weight is required") @Min(value = 1, message = "Points must be at least 1") Integer points,
+
+        @NotNull(message = "Question type is required") QuestionType type) {
+}

--- a/backend/src/main/java/com/learnova/learnova_backend/course/dto/QuestionResponse.java
+++ b/backend/src/main/java/com/learnova/learnova_backend/course/dto/QuestionResponse.java
@@ -1,0 +1,12 @@
+package com.learnova.learnova_backend.course.dto;
+
+import com.learnova.learnova_backend.course.entity.QuestionType;
+import java.util.List;
+
+public record QuestionResponse(
+        Long id,
+        String content,
+        Integer points,
+        QuestionType type,
+        List<AnswerOptionResponse> answerOptions) {
+}

--- a/backend/src/main/java/com/learnova/learnova_backend/course/service/QuizService.java
+++ b/backend/src/main/java/com/learnova/learnova_backend/course/service/QuizService.java
@@ -1,14 +1,21 @@
 package com.learnova.learnova_backend.course.service;
 
+import com.learnova.learnova_backend.course.dto.AnswerOptionRequest;
+import com.learnova.learnova_backend.course.dto.AnswerOptionResponse;
+import com.learnova.learnova_backend.course.dto.QuestionRequest;
+import com.learnova.learnova_backend.course.dto.QuestionResponse;
 import com.learnova.learnova_backend.course.dto.QuizRequest;
 import com.learnova.learnova_backend.course.dto.QuizResponse;
 import com.learnova.learnova_backend.course.dto.QuizUpdateRequest;
+import com.learnova.learnova_backend.course.entity.AnswerOption;
 import com.learnova.learnova_backend.course.entity.Course;
+import com.learnova.learnova_backend.course.entity.Question;
 import com.learnova.learnova_backend.course.entity.Quiz;
 import com.learnova.learnova_backend.course.entity.QuizStatus;
-import com.learnova.learnova_backend.course.entity.Question;
 import com.learnova.learnova_backend.course.entity.Section;
+import com.learnova.learnova_backend.course.repository.AnswerOptionRepository;
 import com.learnova.learnova_backend.course.repository.CourseRepository;
+import com.learnova.learnova_backend.course.repository.QuestionRepository;
 import com.learnova.learnova_backend.course.repository.QuizRepository;
 import com.learnova.learnova_backend.course.repository.SectionRepository;
 import com.learnova.learnova_backend.profile.entity.InstructorProfile;
@@ -20,6 +27,8 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.server.ResponseStatusException;
 
+import java.util.List;
+
 @Service
 @RequiredArgsConstructor
 public class QuizService {
@@ -28,34 +37,33 @@ public class QuizService {
     private final CourseRepository courseRepository;
     private final SectionRepository sectionRepository;
     private final InstructorProfileRepository instructorProfileRepository;
+    private final QuestionRepository questionRepository;
+    private final AnswerOptionRepository answerOptionRepository;
 
     @Transactional
     public QuizResponse createQuiz(CustomUserDetails currentUser, Long courseId, QuizRequest request) {
-
         // 1. Validation de l'existence du cours cible
         Course course = courseRepository.findById(courseId)
                 .orElseThrow(
                         () -> new ResponseStatusException(HttpStatus.NOT_FOUND, "Target course context not found"));
 
-        // 2 & 3. Contrôle strict de propriété : L'instructeur doit être le créateur originel du cours
+        // 2 & 3. Contrôle de propriété
         checkTeacherOwnership(course, currentUser);
 
-        // 4. Validation optionnelle de la Section (si fournie dans la requête)
+        // 4. Validation optionnelle de la Section
         Section section = null;
         if (request.sectionId() != null) {
             section = sectionRepository.findById(request.sectionId())
                     .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND,
                             "Target section context not found"));
 
-            // Cohérence de structure : La section doit impérativement faire partie du cours
-            // spécifié
             if (!section.getCourse().getId().equals(course.getId())) {
                 throw new ResponseStatusException(HttpStatus.BAD_REQUEST,
                         "Invalid scope mapping. The selected section does not belong to the targeted course");
             }
         }
 
-        // 5. Instanciation du modèle avec un statut initial par défaut mis en DRAFT
+        // 5. Instanciation du modèle en DRAFT
         Quiz quiz = Quiz.builder()
                 .title(request.title().trim())
                 .description(request.description() != null ? request.description().trim() : null)
@@ -66,7 +74,6 @@ public class QuizService {
                 .build();
 
         Quiz savedQuiz = quizRepository.save(quiz);
-
         return toResponse(savedQuiz);
     }
 
@@ -77,12 +84,19 @@ public class QuizService {
 
         checkTeacherOwnership(quiz.getCourse(), currentUser);
 
+        if (quiz.getStatus() == QuizStatus.ARCHIVED) {
+            throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "Archived quizzes cannot be modified");
+        }
+
         Section section = null;
         if (request.sectionId() != null) {
             section = sectionRepository.findById(request.sectionId())
-                    .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND, "Target section context not found"));
+                    .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND,
+                            "Target section context not found"));
+
             if (!section.getCourse().getId().equals(quiz.getCourse().getId())) {
-                throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "Invalid scope mapping. The selected section does not belong to the targeted course");
+                throw new ResponseStatusException(HttpStatus.BAD_REQUEST,
+                        "Invalid scope mapping. The selected section does not belong to the targeted course");
             }
         }
 
@@ -107,12 +121,16 @@ public class QuizService {
 
         for (Question question : quiz.getQuestions()) {
             if (question.getAnswerOptions() == null || question.getAnswerOptions().isEmpty()) {
-                throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "Question " + question.getId() + " has no answer options");
+                throw new ResponseStatusException(HttpStatus.BAD_REQUEST,
+                        "Question " + question.getId() + " has no answer options");
             }
 
-            boolean hasCorrectOption = question.getAnswerOptions().stream().anyMatch(option -> Boolean.TRUE.equals(option.getIsCorrect()));
+            boolean hasCorrectOption = question.getAnswerOptions().stream()
+                    .anyMatch(option -> Boolean.TRUE.equals(option.getIsCorrect()));
+
             if (!hasCorrectOption) {
-                throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "Question " + question.getId() + " lacks a true isCorrect target flag");
+                throw new ResponseStatusException(HttpStatus.BAD_REQUEST,
+                        "Question " + question.getId() + " lacks a true isCorrect target flag");
             }
         }
 
@@ -131,6 +149,97 @@ public class QuizService {
         return toResponse(quizRepository.save(quiz));
     }
 
+    @Transactional
+    public QuestionResponse addQuestionToQuiz(CustomUserDetails currentUser, Long quizId, QuestionRequest request) {
+        Quiz quiz = quizRepository.findById(quizId)
+                .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND, "Quiz context not found"));
+
+        checkTeacherOwnership(quiz.getCourse(), currentUser);
+
+        if (quiz.getStatus() == QuizStatus.ARCHIVED) {
+            throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "Cannot add questions to an archived quiz");
+        }
+
+        Question question = Question.builder()
+                .quiz(quiz)
+                .content(request.content().trim())
+                .points(request.points())
+                .type(request.type())
+                .build();
+
+        return toQuestionResponse(questionRepository.save(question));
+    }
+
+    @Transactional
+    public QuestionResponse updateQuestion(CustomUserDetails currentUser, Long questionId, QuestionRequest request) {
+        Question question = questionRepository.findById(questionId)
+                .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND, "Question context not found"));
+
+        checkTeacherOwnership(question.getQuiz().getCourse(), currentUser);
+
+        question.setContent(request.content().trim());
+        question.setPoints(request.points());
+        question.setType(request.type());
+
+        return toQuestionResponse(questionRepository.save(question));
+    }
+
+    @Transactional
+    public void deleteQuestion(CustomUserDetails currentUser, Long questionId) {
+        Question question = questionRepository.findById(questionId)
+                .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND, "Question context not found"));
+
+        checkTeacherOwnership(question.getQuiz().getCourse(), currentUser);
+
+        questionRepository.delete(question);
+    }
+
+    @Transactional
+    public AnswerOptionResponse addOptionToQuestion(CustomUserDetails currentUser, Long questionId,
+            AnswerOptionRequest request) {
+        Question question = questionRepository.findById(questionId)
+
+                .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND, "Question context not found"));
+
+        checkTeacherOwnership(question.getQuiz().getCourse(), currentUser);
+
+        AnswerOption option = AnswerOption.builder()
+                .question(question)
+                .optionText(request.optionText().trim())
+                .isCorrect(request.isCorrect())
+                .build();
+
+        return toAnswerOptionResponse(answerOptionRepository.save(option));
+    }
+
+    @Transactional
+    public AnswerOptionResponse updateAnswerOption(CustomUserDetails currentUser, Long optionId,
+            AnswerOptionRequest request) {
+        AnswerOption option = answerOptionRepository.findById(optionId)
+
+                .orElseThrow(
+                        () -> new ResponseStatusException(HttpStatus.NOT_FOUND, "Answer option context not found"));
+
+        checkTeacherOwnership(option.getQuestion().getQuiz().getCourse(), currentUser);
+
+        option.setOptionText(request.optionText().trim());
+        option.setIsCorrect(request.isCorrect());
+
+        return toAnswerOptionResponse(answerOptionRepository.save(option));
+    }
+
+    @Transactional
+    public void deleteAnswerOption(CustomUserDetails currentUser, Long optionId) {
+        AnswerOption option = answerOptionRepository.findById(optionId)
+                .orElseThrow(
+                        () -> new ResponseStatusException(HttpStatus.NOT_FOUND, "Answer option context not found"));
+
+        checkTeacherOwnership(option.getQuestion().getQuiz().getCourse(), currentUser);
+
+        option.getQuestion().getAnswerOptions().remove(option);
+        answerOptionRepository.delete(option);
+    }
+
     private void checkTeacherOwnership(Course course, CustomUserDetails currentUser) {
         InstructorProfile instructorProfile = instructorProfileRepository.findByUserId(currentUser.getId())
                 .orElseThrow(() -> new ResponseStatusException(HttpStatus.FORBIDDEN,
@@ -142,16 +251,39 @@ public class QuizService {
         }
     }
 
+    // --- MAPPERS UTILITAIRES DE CONVERSION ---
+
     public QuizResponse toResponse(Quiz quiz) {
         return new QuizResponse(
                 quiz.getId(),
                 quiz.getTitle(),
                 quiz.getDescription(),
+
                 quiz.getPassingScore(),
                 quiz.getStatus(),
                 quiz.getCourse().getId(),
                 quiz.getSection() != null ? quiz.getSection().getId() : null,
                 quiz.getCreatedAt(),
                 quiz.getUpdatedAt());
+    }
+
+    public QuestionResponse toQuestionResponse(Question question) {
+        List<AnswerOptionResponse> options = question.getAnswerOptions().stream()
+                .map(this::toAnswerOptionResponse)
+                .toList();
+
+        return new QuestionResponse(
+                question.getId(),
+                question.getContent(),
+                question.getPoints(),
+                question.getType(),
+                options);
+    }
+
+    public AnswerOptionResponse toAnswerOptionResponse(AnswerOption option) {
+        return new AnswerOptionResponse(
+                option.getId(),
+                option.getOptionText(),
+                option.getIsCorrect());
     }
 }


### PR DESCRIPTION
## Technical Implementation Summary

### Granular Assessment Content Management
* Built comprehensive CRUD sub-systems allowing educators to structure questions and multiple-choice configurations within quizzes.
* Provided deep-nested mapping architectures utilizing data models `QuestionRequest`, `AnswerOptionRequest`, and corresponding responses to keep domain state clean.

### Deep Hierarchical Ownership Protection
* Extended the internal `checkTeacherOwnership` guard across the entire mutation grid.
* Configured dynamic database resolution tracking where question nodes resolve parents via `question.getQuiz().getCourse()` and target option keys look up context via `option.getQuestion().getQuiz().getCourse()`, neutralizing cross-tenant data alteration attempts.

### Safe Collection Handlers
* Mapped transactional mutation blocks ensuring cascade elements delete isolated orphaned components inside the collection array without dirty states or indexing leaks.
* Restored structural integrity of mapping functions (`toResponse`, `toQuestionResponse`, `toAnswerOptionResponse`) to output clean unified object graphs.

---

## File Structural Changes
* New Request Structures: backend/src/main/java/com/learnova/learnova_backend/course/dto/QuestionRequest.java & AnswerOptionRequest.java
* New Response Viewports: backend/src/main/java/com/learnova/learnova_backend/course/dto/QuestionResponse.java & AnswerOptionResponse.java
* Updated Functional Coordinator: backend/src/main/java/com/learnova/learnova_backend/course/service/QuizService.java
* Updated Endpoint Gateway Router: backend/src/main/java/com/learnova/learnova_backend/course/controller/InstructorQuizController.java

---

## Verification and Compilation Status
* Local Build Verification: Executed clean dependency tree building steps via `.\mvnw clean compile` following syntax and import alignment passes.
* Compilation Status: Achieved standard system build confirmation status with an absolute `BUILD SUCCESS` declaration in 4.15 seconds and zero runtime type mapping constraints.

Closes #75 