### PR TITLE
Feat/backend quiz attempts

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -209,7 +209,9 @@ The shared client is `src/api/axios.ts`. Never import axios directly in feature 
 | POST | `/api/v1/instructor/courses/sections/{sectionId}/lessons` | INSTRUCTOR (own course; ARCHIVED → 409) |
 | PATCH | `/api/v1/instructor/courses/lessons/{lessonId}` | INSTRUCTOR (own course; ARCHIVED → 409) |
 | DELETE | `/api/v1/instructor/courses/lessons/{lessonId}` | INSTRUCTOR (own course; ARCHIVED → 409) |
+| GET | `/api/v1/instructor/courses/{courseId}/quizzes` | INSTRUCTOR |
 | POST | `/api/v1/instructor/courses/{courseId}/quizzes` | INSTRUCTOR |
+| GET | `/api/v1/instructor/courses/quizzes/{quizId}` | INSTRUCTOR |
 | PUT | `/api/v1/instructor/courses/quizzes/{quizId}` | INSTRUCTOR |
 | PATCH | `/api/v1/instructor/courses/quizzes/{quizId}/publish` | INSTRUCTOR |
 | PATCH | `/api/v1/instructor/courses/quizzes/{quizId}/archive` | INSTRUCTOR |
@@ -227,9 +229,14 @@ The shared client is `src/api/axios.ts`. Never import axios directly in feature 
 | GET | `/api/v1/learner/courses/{courseId}/content` | Authenticated (enrolled learner only; ACTIVE or COMPLETED enrollment; not-enrolled → 404) |
 | PATCH | `/api/v1/lessons/{lessonId}/progress` | Authenticated (enrolled learner only; ACTIVE or COMPLETED enrollment; not-enrolled or CANCELLED → 404; also atomically updates enrollment.progressPercentage; sets status=COMPLETED+completedAt when all lessons done) |
 | GET | `/api/v1/lessons/course/{courseId}/progress` | Authenticated (enrolled learner only; ACTIVE or COMPLETED enrollment; not-enrolled or CANCELLED → 404) |
-| GET | `/api/v1/wishlist` | Authenticated |
-| POST | `/api/v1/wishlist/course/{courseId}` | Authenticated |
-| DELETE | `/api/v1/wishlist/course/{courseId}` | Authenticated |
+| GET | `/api/v1/wishlist` | LEARNER |
+| POST | `/api/v1/wishlist/course/{courseId}` | LEARNER |
+| DELETE | `/api/v1/wishlist/course/{courseId}` | LEARNER |
+| GET | `/api/v1/learner/courses/{courseId}/quizzes` | LEARNER (enrolled; ACTIVE or COMPLETED; PUBLISHED quizzes only; no isCorrect) |
+| GET | `/api/v1/learner/quizzes/{quizId}` | LEARNER (enrolled; PUBLISHED only; no isCorrect on options) |
+| POST | `/api/v1/learner/quizzes/{quizId}/attempts` | LEARNER (enrolled; PUBLISHED; reuses existing IN_PROGRESS attempt) |
+| POST | `/api/v1/learner/quiz-attempts/{attemptId}/submit` | LEARNER (own attempt; IN_PROGRESS only; 409 if already SUBMITTED) |
+| GET | `/api/v1/learner/quiz-attempts/{attemptId}` | LEARNER (own attempt only) |
 
 Swagger UI: `http://localhost:8080/swagger-ui/index.html`
 
@@ -258,3 +265,5 @@ Rules:
 - Read graphify-out/GRAPH_REPORT.md only for broad architecture review or when query/path/explain do not surface enough context.
 - After modifying code, run `graphify update .` to keep the graph current (AST-only, no API cost).
 - `graphify-out/` is a generated local artifact and is git-ignored. Do not commit it.
+
+If the `graphify` CLI is not installed, skip graph refresh and report it explicitly. Do not block the task on graphify.

--- a/CURRENT_STATE.md
+++ b/CURRENT_STATE.md
@@ -9,7 +9,7 @@ Learnova
 
 ## Current Milestone
 
-Frontend integration: learner course player, instructor content builder, instructor quiz management, admin instructor-approvals page, public course detail page, and saved-courses dashboard page are all wired to real backend APIs. The wishlist save-for-later action is integrated on both the public course detail page and the saved-courses dashboard page. Remaining gap is the learner quiz-taking flow.
+Frontend integration: learner course player, instructor content builder, instructor quiz management, admin instructor-approvals page, public course detail page, and saved-courses dashboard page are all wired to real backend APIs. The wishlist save-for-later action is integrated on both the public course detail page and the saved-courses dashboard page. Learner quiz-taking backend is complete (attempt creation, answer submission, scoring, result retrieval). Remaining gap is the learner quiz-taking frontend.
 
 ## Backend Status
 
@@ -38,6 +38,14 @@ The backend is feature-complete for the current phase. These modules exist and a
 - Quiz authoring: instructor CRUD for quizzes, questions, and answer options, plus publish/archive
   - `GET /api/v1/instructor/courses/{courseId}/quizzes` — lists all quizzes for an instructor-owned course; consumed by `InstructorQuizzesPage` on load
   - `GET /api/v1/instructor/courses/quizzes/{quizId}` — returns quiz detail with questions and answer options; consumed by `InstructorQuizzesPage` on expand
+- Learner quiz-taking: enrolled learners can list, preview, attempt, submit, and retrieve quiz results
+  - `GET /api/v1/learner/courses/{courseId}/quizzes` — lists PUBLISHED quizzes for an enrolled course; excludes DRAFT and ARCHIVED; no isCorrect in response
+  - `GET /api/v1/learner/quizzes/{quizId}` — returns learner-safe quiz detail (questions + options without isCorrect); enrollment-gated
+  - `POST /api/v1/learner/quizzes/{quizId}/attempts` — starts or resumes an IN_PROGRESS attempt; idempotent (returns existing attempt if one is in progress)
+  - `POST /api/v1/learner/quiz-attempts/{attemptId}/submit` — submits answers; validates all quiz questions answered, no duplicates, options belong to questions; computes score: `scorePercentage = floor((earnedPoints * 100) / totalPoints)`, `passed = scorePercentage >= quiz.passingScore`; 409 if already SUBMITTED
+  - `GET /api/v1/learner/quiz-attempts/{attemptId}` — returns submitted attempt result with per-question breakdown; ownership-gated (own attempt only)
+  - Access control: enrollment must be ACTIVE or COMPLETED; CANCELLED → 404; DRAFT/ARCHIVED quiz → 404; non-enrolled → 404 (content enumeration protection)
+  - New entities: `QuizAttempt`, `QuizAttemptAnswer`, `QuizAttemptStatus` (IN_PROGRESS, SUBMITTED); v1 supports one selected option per question
 - Wishlist: list, add course, remove course
 - Security hardening: JWT filter, account-status checks, and error dispatch (consistent 401/403 JSON responses)
 
@@ -87,7 +95,7 @@ Still mocked or placeholder:
 - No catalog-card wishlist controls; `CourseCatalogCard` intentionally does not show save/unsave yet (deferred decision)
 - No per-course wishlist status endpoint on the backend; saved state is derived from `GET /api/v1/wishlist?size=200` (v1 size cap)
 - No auto-remove from wishlist after enrollment; wishlist and enrollment are independent at both the backend and frontend layers
-- No learner quiz-taking UI, attempts, scoring, or results (instructor quiz authoring and management is implemented at `/instructor/courses/:courseId/quizzes`; no learner quiz attempt flow, no submission tracking, no per-learner score recording)
+- No learner quiz-taking UI (backend learner quiz-taking is now complete; no frontend React pages for quiz attempts yet)
 - No question or answer option ordering support (new questions/options are always appended; no drag-reorder)
 - No unpublish or restore-from-archived quiz flow (publish is DRAFT→PUBLISHED; archive is terminal; no reverse transition in UI)
 - No profile switch UI (backend `POST /api/v1/profile/switch` exists; no switcher component wired)

--- a/backend/src/main/java/com/learnova/learnova_backend/course/controller/LearnerQuizController.java
+++ b/backend/src/main/java/com/learnova/learnova_backend/course/controller/LearnerQuizController.java
@@ -1,0 +1,68 @@
+package com.learnova.learnova_backend.course.controller;
+
+import com.learnova.learnova_backend.course.dto.*;
+import com.learnova.learnova_backend.course.service.LearnerQuizService;
+import com.learnova.learnova_backend.security.CustomUserDetails;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+@RestController
+@RequestMapping("/api/v1/learner")
+@RequiredArgsConstructor
+@PreAuthorize("hasRole('LEARNER')")
+public class LearnerQuizController {
+
+    private final LearnerQuizService learnerQuizService;
+
+    @GetMapping("/courses/{courseId}/quizzes")
+    public ResponseEntity<List<LearnerQuizSummaryResponse>> listQuizzes(
+            @PathVariable Long courseId,
+            @AuthenticationPrincipal CustomUserDetails currentUser) {
+
+        return ResponseEntity.ok(
+                learnerQuizService.listPublishedQuizzes(currentUser.getId(), courseId));
+    }
+
+    @GetMapping("/quizzes/{quizId}")
+    public ResponseEntity<LearnerQuizDetailResponse> getQuizDetail(
+            @PathVariable Long quizId,
+            @AuthenticationPrincipal CustomUserDetails currentUser) {
+
+        return ResponseEntity.ok(
+                learnerQuizService.getQuizForTaking(currentUser.getId(), quizId));
+    }
+
+    @PostMapping("/quizzes/{quizId}/attempts")
+    public ResponseEntity<QuizAttemptResponse> startAttempt(
+            @PathVariable Long quizId,
+            @AuthenticationPrincipal CustomUserDetails currentUser) {
+
+        return ResponseEntity.ok(
+                learnerQuizService.startOrResumeAttempt(currentUser.getId(), quizId));
+    }
+
+    @PostMapping("/quiz-attempts/{attemptId}/submit")
+    public ResponseEntity<QuizAttemptResponse> submitAttempt(
+            @PathVariable Long attemptId,
+            @AuthenticationPrincipal CustomUserDetails currentUser,
+            @Valid @RequestBody QuizAttemptSubmitRequest request) {
+
+        return ResponseEntity.ok(
+                learnerQuizService.submitAttempt(currentUser.getId(), attemptId, request));
+    }
+
+    @GetMapping("/quiz-attempts/{attemptId}")
+    public ResponseEntity<QuizAttemptResponse> getAttemptResult(
+            @PathVariable Long attemptId,
+            @AuthenticationPrincipal CustomUserDetails currentUser) {
+
+        return ResponseEntity.ok(
+                learnerQuizService.getAttemptResult(currentUser.getId(), attemptId));
+    }
+}

--- a/backend/src/main/java/com/learnova/learnova_backend/course/dto/LearnerAnswerOptionResponse.java
+++ b/backend/src/main/java/com/learnova/learnova_backend/course/dto/LearnerAnswerOptionResponse.java
@@ -1,0 +1,6 @@
+package com.learnova.learnova_backend.course.dto;
+
+public record LearnerAnswerOptionResponse(
+        Long id,
+        String optionText) {
+}

--- a/backend/src/main/java/com/learnova/learnova_backend/course/dto/LearnerQuestionResponse.java
+++ b/backend/src/main/java/com/learnova/learnova_backend/course/dto/LearnerQuestionResponse.java
@@ -1,0 +1,13 @@
+package com.learnova.learnova_backend.course.dto;
+
+import com.learnova.learnova_backend.course.entity.QuestionType;
+
+import java.util.List;
+
+public record LearnerQuestionResponse(
+        Long id,
+        String content,
+        Integer points,
+        QuestionType type,
+        List<LearnerAnswerOptionResponse> answerOptions) {
+}

--- a/backend/src/main/java/com/learnova/learnova_backend/course/dto/LearnerQuizDetailResponse.java
+++ b/backend/src/main/java/com/learnova/learnova_backend/course/dto/LearnerQuizDetailResponse.java
@@ -1,0 +1,13 @@
+package com.learnova.learnova_backend.course.dto;
+
+import java.util.List;
+
+public record LearnerQuizDetailResponse(
+        Long id,
+        String title,
+        String description,
+        Integer passingScore,
+        Long courseId,
+        Long sectionId,
+        List<LearnerQuestionResponse> questions) {
+}

--- a/backend/src/main/java/com/learnova/learnova_backend/course/dto/LearnerQuizSummaryResponse.java
+++ b/backend/src/main/java/com/learnova/learnova_backend/course/dto/LearnerQuizSummaryResponse.java
@@ -1,0 +1,10 @@
+package com.learnova.learnova_backend.course.dto;
+
+public record LearnerQuizSummaryResponse(
+        Long id,
+        String title,
+        String description,
+        Integer passingScore,
+        Long courseId,
+        Long sectionId) {
+}

--- a/backend/src/main/java/com/learnova/learnova_backend/course/dto/QuizAttemptAnswerRequest.java
+++ b/backend/src/main/java/com/learnova/learnova_backend/course/dto/QuizAttemptAnswerRequest.java
@@ -1,0 +1,8 @@
+package com.learnova.learnova_backend.course.dto;
+
+import jakarta.validation.constraints.NotNull;
+
+public record QuizAttemptAnswerRequest(
+        @NotNull Long questionId,
+        @NotNull Long selectedOptionId) {
+}

--- a/backend/src/main/java/com/learnova/learnova_backend/course/dto/QuizAttemptAnswerResultResponse.java
+++ b/backend/src/main/java/com/learnova/learnova_backend/course/dto/QuizAttemptAnswerResultResponse.java
@@ -1,0 +1,8 @@
+package com.learnova.learnova_backend.course.dto;
+
+public record QuizAttemptAnswerResultResponse(
+        Long questionId,
+        Long selectedOptionId,
+        Boolean correct,
+        Integer earnedPoints) {
+}

--- a/backend/src/main/java/com/learnova/learnova_backend/course/dto/QuizAttemptResponse.java
+++ b/backend/src/main/java/com/learnova/learnova_backend/course/dto/QuizAttemptResponse.java
@@ -1,0 +1,18 @@
+package com.learnova.learnova_backend.course.dto;
+
+import com.learnova.learnova_backend.course.entity.QuizAttemptStatus;
+
+import java.time.Instant;
+import java.util.List;
+
+public record QuizAttemptResponse(
+        Long id,
+        Long quizId,
+        QuizAttemptStatus status,
+        Integer earnedPoints,
+        Integer totalPoints,
+        Integer scorePercentage,
+        Boolean passed,
+        Instant submittedAt,
+        List<QuizAttemptAnswerResultResponse> answerResults) {
+}

--- a/backend/src/main/java/com/learnova/learnova_backend/course/dto/QuizAttemptSubmitRequest.java
+++ b/backend/src/main/java/com/learnova/learnova_backend/course/dto/QuizAttemptSubmitRequest.java
@@ -1,0 +1,10 @@
+package com.learnova.learnova_backend.course.dto;
+
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.NotEmpty;
+
+import java.util.List;
+
+public record QuizAttemptSubmitRequest(
+        @NotEmpty @Valid List<QuizAttemptAnswerRequest> answers) {
+}

--- a/backend/src/main/java/com/learnova/learnova_backend/course/entity/QuizAttempt.java
+++ b/backend/src/main/java/com/learnova/learnova_backend/course/entity/QuizAttempt.java
@@ -1,0 +1,79 @@
+package com.learnova.learnova_backend.course.entity;
+
+import com.learnova.learnova_backend.profile.entity.LearnerProfile;
+import jakarta.persistence.*;
+import lombok.*;
+
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.List;
+
+@Entity
+@Table(name = "quiz_attempts")
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class QuizAttempt {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY, optional = false)
+    @JoinColumn(name = "learner_profile_id", nullable = false,
+            foreignKey = @ForeignKey(name = "fk_quiz_attempts_learner_profile"))
+    private LearnerProfile learnerProfile;
+
+    @ManyToOne(fetch = FetchType.LAZY, optional = false)
+    @JoinColumn(name = "quiz_id", nullable = false,
+            foreignKey = @ForeignKey(name = "fk_quiz_attempts_quiz"))
+    private Quiz quiz;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false, length = 20)
+    private QuizAttemptStatus status;
+
+    @Column(name = "score_percentage")
+    private Integer scorePercentage;
+
+    @Column(name = "total_points")
+    private Integer totalPoints;
+
+    @Column(name = "earned_points")
+    private Integer earnedPoints;
+
+    private Boolean passed;
+
+    @Column(name = "started_at", nullable = false)
+    private Instant startedAt;
+
+    @Column(name = "submitted_at")
+    private Instant submittedAt;
+
+    @Column(name = "created_at", nullable = false, updatable = false)
+    private Instant createdAt;
+
+    @Column(name = "updated_at", nullable = false)
+    private Instant updatedAt;
+
+    @OneToMany(mappedBy = "attempt", cascade = CascadeType.ALL, orphanRemoval = true)
+    @Builder.Default
+    private List<QuizAttemptAnswer> answers = new ArrayList<>();
+
+    @PrePersist
+    void onCreate() {
+        Instant now = Instant.now();
+        this.createdAt = now;
+        this.updatedAt = now;
+        if (this.startedAt == null) {
+            this.startedAt = now;
+        }
+    }
+
+    @PreUpdate
+    void onUpdate() {
+        this.updatedAt = Instant.now();
+    }
+}

--- a/backend/src/main/java/com/learnova/learnova_backend/course/entity/QuizAttemptAnswer.java
+++ b/backend/src/main/java/com/learnova/learnova_backend/course/entity/QuizAttemptAnswer.java
@@ -1,0 +1,59 @@
+package com.learnova.learnova_backend.course.entity;
+
+import jakarta.persistence.*;
+import lombok.*;
+
+import java.time.Instant;
+
+@Entity
+@Table(name = "quiz_attempt_answers")
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class QuizAttemptAnswer {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY, optional = false)
+    @JoinColumn(name = "attempt_id", nullable = false,
+            foreignKey = @ForeignKey(name = "fk_quiz_attempt_answers_attempt"))
+    private QuizAttempt attempt;
+
+    @ManyToOne(fetch = FetchType.LAZY, optional = false)
+    @JoinColumn(name = "question_id", nullable = false,
+            foreignKey = @ForeignKey(name = "fk_quiz_attempt_answers_question"))
+    private Question question;
+
+    @ManyToOne(fetch = FetchType.LAZY, optional = false)
+    @JoinColumn(name = "selected_option_id", nullable = false,
+            foreignKey = @ForeignKey(name = "fk_quiz_attempt_answers_option"))
+    private AnswerOption selectedOption;
+
+    @Column(nullable = false)
+    private Boolean correct;
+
+    @Column(name = "earned_points", nullable = false)
+    private Integer earnedPoints;
+
+    @Column(name = "created_at", nullable = false, updatable = false)
+    private Instant createdAt;
+
+    @Column(name = "updated_at", nullable = false)
+    private Instant updatedAt;
+
+    @PrePersist
+    void onCreate() {
+        Instant now = Instant.now();
+        this.createdAt = now;
+        this.updatedAt = now;
+    }
+
+    @PreUpdate
+    void onUpdate() {
+        this.updatedAt = Instant.now();
+    }
+}

--- a/backend/src/main/java/com/learnova/learnova_backend/course/entity/QuizAttemptStatus.java
+++ b/backend/src/main/java/com/learnova/learnova_backend/course/entity/QuizAttemptStatus.java
@@ -1,0 +1,6 @@
+package com.learnova.learnova_backend.course.entity;
+
+public enum QuizAttemptStatus {
+    IN_PROGRESS,
+    SUBMITTED
+}

--- a/backend/src/main/java/com/learnova/learnova_backend/course/repository/QuizAttemptAnswerRepository.java
+++ b/backend/src/main/java/com/learnova/learnova_backend/course/repository/QuizAttemptAnswerRepository.java
@@ -1,0 +1,13 @@
+package com.learnova.learnova_backend.course.repository;
+
+import com.learnova.learnova_backend.course.entity.QuizAttemptAnswer;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+
+@Repository
+public interface QuizAttemptAnswerRepository extends JpaRepository<QuizAttemptAnswer, Long> {
+
+    List<QuizAttemptAnswer> findByAttemptId(Long attemptId);
+}

--- a/backend/src/main/java/com/learnova/learnova_backend/course/repository/QuizAttemptRepository.java
+++ b/backend/src/main/java/com/learnova/learnova_backend/course/repository/QuizAttemptRepository.java
@@ -1,0 +1,17 @@
+package com.learnova.learnova_backend.course.repository;
+
+import com.learnova.learnova_backend.course.entity.QuizAttempt;
+import com.learnova.learnova_backend.course.entity.QuizAttemptStatus;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.Optional;
+
+@Repository
+public interface QuizAttemptRepository extends JpaRepository<QuizAttempt, Long> {
+
+    Optional<QuizAttempt> findByIdAndLearnerProfileId(Long id, Long learnerProfileId);
+
+    Optional<QuizAttempt> findByLearnerProfileIdAndQuizIdAndStatus(
+            Long learnerProfileId, Long quizId, QuizAttemptStatus status);
+}

--- a/backend/src/main/java/com/learnova/learnova_backend/course/repository/QuizRepository.java
+++ b/backend/src/main/java/com/learnova/learnova_backend/course/repository/QuizRepository.java
@@ -1,6 +1,7 @@
 package com.learnova.learnova_backend.course.repository;
 
 import com.learnova.learnova_backend.course.entity.Quiz;
+import com.learnova.learnova_backend.course.entity.QuizStatus;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
@@ -9,12 +10,11 @@ import java.util.List;
 @Repository
 public interface QuizRepository extends JpaRepository<Quiz, Long> {
 
-    // Récupérer tous les quiz associés à un cours spécifique
     List<Quiz> findByCourseId(Long courseId);
 
-    // Récupérer tous les quiz d'un cours, triés par id croissant (ordre de création stable)
     List<Quiz> findByCourseIdOrderByIdAsc(Long courseId);
 
-    // Récupérer tous les quiz associés à une section spécifique
     List<Quiz> findBySectionId(Long sectionId);
+
+    List<Quiz> findByCourseIdAndStatusOrderByIdAsc(Long courseId, QuizStatus status);
 }

--- a/backend/src/main/java/com/learnova/learnova_backend/course/service/LearnerQuizService.java
+++ b/backend/src/main/java/com/learnova/learnova_backend/course/service/LearnerQuizService.java
@@ -1,0 +1,250 @@
+package com.learnova.learnova_backend.course.service;
+
+import com.learnova.learnova_backend.course.dto.*;
+import com.learnova.learnova_backend.course.entity.*;
+import com.learnova.learnova_backend.course.repository.QuizAttemptAnswerRepository;
+import com.learnova.learnova_backend.course.repository.QuizAttemptRepository;
+import com.learnova.learnova_backend.course.repository.QuizRepository;
+import com.learnova.learnova_backend.enrollment.entity.EnrollmentStatus;
+import com.learnova.learnova_backend.enrollment.repository.EnrollmentRepository;
+import com.learnova.learnova_backend.profile.entity.LearnerProfile;
+import com.learnova.learnova_backend.profile.repository.LearnerProfileRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.server.ResponseStatusException;
+
+import java.time.Instant;
+import java.util.*;
+import java.util.stream.Collectors;
+
+@Service
+@RequiredArgsConstructor
+public class LearnerQuizService {
+
+    private final QuizRepository quizRepository;
+    private final QuizAttemptRepository quizAttemptRepository;
+    private final QuizAttemptAnswerRepository quizAttemptAnswerRepository;
+    private final LearnerProfileRepository learnerProfileRepository;
+    private final EnrollmentRepository enrollmentRepository;
+
+    private static final List<EnrollmentStatus> ACTIVE_STATUSES =
+            List.of(EnrollmentStatus.ACTIVE, EnrollmentStatus.COMPLETED);
+
+    @Transactional(readOnly = true)
+    public List<LearnerQuizSummaryResponse> listPublishedQuizzes(Long userId, Long courseId) {
+        LearnerProfile learnerProfile = resolveLearnerProfile(userId);
+        checkEnrollment(learnerProfile.getId(), courseId);
+
+        return quizRepository.findByCourseIdAndStatusOrderByIdAsc(courseId, QuizStatus.PUBLISHED)
+                .stream()
+                .map(quiz -> new LearnerQuizSummaryResponse(
+                        quiz.getId(),
+                        quiz.getTitle(),
+                        quiz.getDescription(),
+                        quiz.getPassingScore(),
+                        quiz.getCourse().getId(),
+                        quiz.getSection() != null ? quiz.getSection().getId() : null))
+                .toList();
+    }
+
+    @Transactional(readOnly = true)
+    public LearnerQuizDetailResponse getQuizForTaking(Long userId, Long quizId) {
+        Quiz quiz = resolvePublishedQuiz(quizId);
+        LearnerProfile learnerProfile = resolveLearnerProfile(userId);
+        checkEnrollment(learnerProfile.getId(), quiz.getCourse().getId());
+
+        List<LearnerQuestionResponse> questions = quiz.getQuestions().stream()
+                .map(q -> new LearnerQuestionResponse(
+                        q.getId(),
+                        q.getContent(),
+                        q.getPoints(),
+                        q.getType(),
+                        q.getAnswerOptions().stream()
+                                .map(o -> new LearnerAnswerOptionResponse(o.getId(), o.getOptionText()))
+                                .toList()))
+                .toList();
+
+        return new LearnerQuizDetailResponse(
+                quiz.getId(),
+                quiz.getTitle(),
+                quiz.getDescription(),
+                quiz.getPassingScore(),
+                quiz.getCourse().getId(),
+                quiz.getSection() != null ? quiz.getSection().getId() : null,
+                questions);
+    }
+
+    @Transactional
+    public QuizAttemptResponse startOrResumeAttempt(Long userId, Long quizId) {
+        Quiz quiz = resolvePublishedQuiz(quizId);
+        LearnerProfile learnerProfile = resolveLearnerProfile(userId);
+        checkEnrollment(learnerProfile.getId(), quiz.getCourse().getId());
+
+        Optional<QuizAttempt> existing = quizAttemptRepository
+                .findByLearnerProfileIdAndQuizIdAndStatus(
+                        learnerProfile.getId(), quizId, QuizAttemptStatus.IN_PROGRESS);
+        if (existing.isPresent()) {
+            return toAttemptResponse(existing.get(), List.of());
+        }
+
+        QuizAttempt attempt = QuizAttempt.builder()
+                .learnerProfile(learnerProfile)
+                .quiz(quiz)
+                .status(QuizAttemptStatus.IN_PROGRESS)
+                .build();
+        return toAttemptResponse(quizAttemptRepository.save(attempt), List.of());
+    }
+
+    @Transactional
+    public QuizAttemptResponse submitAttempt(Long userId, Long attemptId, QuizAttemptSubmitRequest request) {
+        LearnerProfile learnerProfile = resolveLearnerProfile(userId);
+
+        QuizAttempt attempt = quizAttemptRepository
+                .findByIdAndLearnerProfileId(attemptId, learnerProfile.getId())
+                .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND, "Attempt not found"));
+
+        if (attempt.getStatus() == QuizAttemptStatus.SUBMITTED) {
+            throw new ResponseStatusException(HttpStatus.CONFLICT, "Attempt already submitted");
+        }
+
+        Quiz quiz = attempt.getQuiz();
+        List<Question> questions = quiz.getQuestions();
+
+        Map<Long, Question> questionMap = questions.stream()
+                .collect(Collectors.toMap(Question::getId, q -> q));
+
+        Map<Long, Map<Long, AnswerOption>> questionOptionMap = new HashMap<>();
+        for (Question q : questions) {
+            Map<Long, AnswerOption> optionMap = q.getAnswerOptions().stream()
+                    .collect(Collectors.toMap(AnswerOption::getId, o -> o));
+            questionOptionMap.put(q.getId(), optionMap);
+        }
+
+        List<QuizAttemptAnswerRequest> answers = request.answers();
+
+        Set<Long> answeredIds = new HashSet<>();
+        for (QuizAttemptAnswerRequest a : answers) {
+            if (!answeredIds.add(a.questionId())) {
+                throw new ResponseStatusException(HttpStatus.BAD_REQUEST,
+                        "Duplicate answer for question: " + a.questionId());
+            }
+        }
+
+        if (!answeredIds.equals(questionMap.keySet())) {
+            throw new ResponseStatusException(HttpStatus.BAD_REQUEST,
+                    "Answer set does not match quiz questions");
+        }
+
+        for (QuizAttemptAnswerRequest a : answers) {
+            Map<Long, AnswerOption> optionsForQuestion = questionOptionMap.get(a.questionId());
+            if (!optionsForQuestion.containsKey(a.selectedOptionId())) {
+                throw new ResponseStatusException(HttpStatus.BAD_REQUEST,
+                        "Answer option does not belong to the specified question");
+            }
+        }
+
+        int totalPoints = questions.stream().mapToInt(Question::getPoints).sum();
+        if (totalPoints == 0) {
+            throw new ResponseStatusException(HttpStatus.BAD_REQUEST,
+                    "Quiz has no scoreable points");
+        }
+
+        int earnedPoints = 0;
+        List<QuizAttemptAnswerResultResponse> results = new ArrayList<>();
+
+        for (QuizAttemptAnswerRequest a : answers) {
+            Question question = questionMap.get(a.questionId());
+            AnswerOption selectedOption = questionOptionMap.get(a.questionId()).get(a.selectedOptionId());
+            boolean correct = Boolean.TRUE.equals(selectedOption.getIsCorrect());
+            int points = correct ? question.getPoints() : 0;
+            earnedPoints += points;
+
+            quizAttemptAnswerRepository.save(QuizAttemptAnswer.builder()
+                    .attempt(attempt)
+                    .question(question)
+                    .selectedOption(selectedOption)
+                    .correct(correct)
+                    .earnedPoints(points)
+                    .build());
+
+            results.add(new QuizAttemptAnswerResultResponse(
+                    a.questionId(), a.selectedOptionId(), correct, points));
+        }
+
+        int scorePercentage = (earnedPoints * 100) / totalPoints;
+        boolean passed = scorePercentage >= quiz.getPassingScore();
+        Instant now = Instant.now();
+
+        attempt.setStatus(QuizAttemptStatus.SUBMITTED);
+        attempt.setEarnedPoints(earnedPoints);
+        attempt.setTotalPoints(totalPoints);
+        attempt.setScorePercentage(scorePercentage);
+        attempt.setPassed(passed);
+        attempt.setSubmittedAt(now);
+        quizAttemptRepository.save(attempt);
+
+        return new QuizAttemptResponse(
+                attempt.getId(), quiz.getId(), QuizAttemptStatus.SUBMITTED,
+                earnedPoints, totalPoints, scorePercentage, passed, now, results);
+    }
+
+    @Transactional(readOnly = true)
+    public QuizAttemptResponse getAttemptResult(Long userId, Long attemptId) {
+        LearnerProfile learnerProfile = resolveLearnerProfile(userId);
+
+        QuizAttempt attempt = quizAttemptRepository
+                .findByIdAndLearnerProfileId(attemptId, learnerProfile.getId())
+                .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND, "Attempt not found"));
+
+        List<QuizAttemptAnswerResultResponse> results = quizAttemptAnswerRepository
+                .findByAttemptId(attemptId)
+                .stream()
+                .map(a -> new QuizAttemptAnswerResultResponse(
+                        a.getQuestion().getId(),
+                        a.getSelectedOption().getId(),
+                        a.getCorrect(),
+                        a.getEarnedPoints()))
+                .toList();
+
+        return toAttemptResponse(attempt, results);
+    }
+
+    private LearnerProfile resolveLearnerProfile(Long userId) {
+        return learnerProfileRepository.findByUserId(userId)
+                .orElseThrow(() -> new ResponseStatusException(
+                        HttpStatus.NOT_FOUND, "Learner profile not found"));
+    }
+
+    private void checkEnrollment(Long learnerProfileId, Long courseId) {
+        boolean enrolled = enrollmentRepository.existsByLearnerProfileIdAndCourseIdAndStatusIn(
+                learnerProfileId, courseId, ACTIVE_STATUSES);
+        if (!enrolled) {
+            throw new ResponseStatusException(HttpStatus.NOT_FOUND, "Course not found");
+        }
+    }
+
+    private Quiz resolvePublishedQuiz(Long quizId) {
+        Quiz quiz = quizRepository.findById(quizId)
+                .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND, "Quiz not found"));
+        if (quiz.getStatus() != QuizStatus.PUBLISHED) {
+            throw new ResponseStatusException(HttpStatus.NOT_FOUND, "Quiz not found");
+        }
+        return quiz;
+    }
+
+    private QuizAttemptResponse toAttemptResponse(QuizAttempt attempt,
+                                                   List<QuizAttemptAnswerResultResponse> results) {
+        return new QuizAttemptResponse(
+                attempt.getId(),
+                attempt.getQuiz().getId(),
+                attempt.getStatus(),
+                attempt.getEarnedPoints(),
+                attempt.getTotalPoints(),
+                attempt.getScorePercentage(),
+                attempt.getPassed(),
+                attempt.getSubmittedAt(),
+                results);
+    }
+}

--- a/backend/src/test/java/com/learnova/learnova_backend/course/LearnerQuizIntegrationTest.java
+++ b/backend/src/test/java/com/learnova/learnova_backend/course/LearnerQuizIntegrationTest.java
@@ -1,0 +1,639 @@
+package com.learnova.learnova_backend.course;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.learnova.learnova_backend.auth.dto.LoginRequest;
+import com.learnova.learnova_backend.auth.dto.RegisterRequest;
+import com.learnova.learnova_backend.course.entity.*;
+import com.learnova.learnova_backend.course.repository.*;
+import com.learnova.learnova_backend.enrollment.entity.Enrollment;
+import com.learnova.learnova_backend.enrollment.entity.EnrollmentStatus;
+import com.learnova.learnova_backend.enrollment.repository.EnrollmentRepository;
+import com.learnova.learnova_backend.profile.entity.InstructorApprovalStatus;
+import com.learnova.learnova_backend.profile.entity.InstructorProfile;
+import com.learnova.learnova_backend.profile.entity.LearnerProfile;
+import com.learnova.learnova_backend.profile.repository.InstructorProfileRepository;
+import com.learnova.learnova_backend.profile.repository.LearnerProfileRepository;
+import com.learnova.learnova_backend.user.entity.User;
+import com.learnova.learnova_backend.user.repository.UserRepository;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.MediaType;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+import java.util.Map;
+
+import static org.hamcrest.Matchers.*;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+@SpringBootTest
+@AutoConfigureMockMvc
+@ActiveProfiles("test")
+@Transactional
+class LearnerQuizIntegrationTest {
+
+    @Autowired private MockMvc mockMvc;
+    @Autowired private ObjectMapper objectMapper;
+    @Autowired private UserRepository userRepository;
+    @Autowired private InstructorProfileRepository instructorProfileRepository;
+    @Autowired private CategoryRepository categoryRepository;
+    @Autowired private CourseRepository courseRepository;
+    @Autowired private QuizRepository quizRepository;
+    @Autowired private QuestionRepository questionRepository;
+    @Autowired private AnswerOptionRepository answerOptionRepository;
+    @Autowired private LearnerProfileRepository learnerProfileRepository;
+    @Autowired private EnrollmentRepository enrollmentRepository;
+
+    // ─── 1. Enrolled learner lists published quizzes ──────────────────────────
+
+    @Test
+    void enrolledLearnerListsPublishedQuizzes() throws Exception {
+        QuizFixture f = buildFixture("inst.lq1@quiz.test");
+        String learnerToken = registerAndLogin("learner.lq1@quiz.test", "password123");
+        enroll("learner.lq1@quiz.test", f.course(), EnrollmentStatus.ACTIVE);
+
+        mockMvc.perform(get("/api/v1/learner/courses/{id}/quizzes", f.course().getId())
+                        .header("Authorization", "Bearer " + learnerToken))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.length()").value(1))
+                .andExpect(jsonPath("$[0].id").value(f.quiz().getId()))
+                .andExpect(jsonPath("$[0].title").value("Test Quiz"))
+                .andExpect(jsonPath("$[0].passingScore").value(70))
+                .andExpect(jsonPath("$[0].courseId").value(f.course().getId()));
+    }
+
+    // ─── 2. List excludes DRAFT and ARCHIVED quizzes ──────────────────────────
+
+    @Test
+    void listExcludesDraftAndArchivedQuizzes() throws Exception {
+        QuizFixture f = buildFixture("inst.lq2@quiz.test");
+        createMinimalQuiz(f.course(), "Draft Quiz", QuizStatus.DRAFT);
+        createMinimalQuiz(f.course(), "Archived Quiz", QuizStatus.ARCHIVED);
+        String learnerToken = registerAndLogin("learner.lq2@quiz.test", "password123");
+        enroll("learner.lq2@quiz.test", f.course(), EnrollmentStatus.ACTIVE);
+
+        mockMvc.perform(get("/api/v1/learner/courses/{id}/quizzes", f.course().getId())
+                        .header("Authorization", "Bearer " + learnerToken))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.length()").value(1))
+                .andExpect(jsonPath("$[0].title").value("Test Quiz"));
+    }
+
+    // ─── 3. Not enrolled learner cannot list quizzes ──────────────────────────
+
+    @Test
+    void notEnrolledLearnerCannotListQuizzes() throws Exception {
+        QuizFixture f = buildFixture("inst.lq3@quiz.test");
+        String learnerToken = registerAndLogin("learner.lq3@quiz.test", "password123");
+
+        mockMvc.perform(get("/api/v1/learner/courses/{id}/quizzes", f.course().getId())
+                        .header("Authorization", "Bearer " + learnerToken))
+                .andExpect(status().isNotFound());
+    }
+
+    // ─── 4. Enrolled learner fetches quiz detail ───────────────────────────────
+
+    @Test
+    void enrolledLearnerFetchesPublishedQuizDetail() throws Exception {
+        QuizFixture f = buildFixture("inst.lq4@quiz.test");
+        String learnerToken = registerAndLogin("learner.lq4@quiz.test", "password123");
+        enroll("learner.lq4@quiz.test", f.course(), EnrollmentStatus.ACTIVE);
+
+        mockMvc.perform(get("/api/v1/learner/quizzes/{id}", f.quiz().getId())
+                        .header("Authorization", "Bearer " + learnerToken))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.id").value(f.quiz().getId()))
+                .andExpect(jsonPath("$.title").value("Test Quiz"))
+                .andExpect(jsonPath("$.passingScore").value(70))
+                .andExpect(jsonPath("$.questions.length()").value(2))
+                .andExpect(jsonPath("$.questions[0].answerOptions.length()").value(2));
+    }
+
+    // ─── 5. Quiz detail does not expose isCorrect ─────────────────────────────
+
+    @Test
+    void quizDetailDoesNotExposeIsCorrect() throws Exception {
+        QuizFixture f = buildFixture("inst.lq5@quiz.test");
+        String learnerToken = registerAndLogin("learner.lq5@quiz.test", "password123");
+        enroll("learner.lq5@quiz.test", f.course(), EnrollmentStatus.ACTIVE);
+
+        mockMvc.perform(get("/api/v1/learner/quizzes/{id}", f.quiz().getId())
+                        .header("Authorization", "Bearer " + learnerToken))
+                .andExpect(status().isOk())
+                .andExpect(content().string(not(containsString("isCorrect"))));
+    }
+
+    // ─── 6. Learner cannot fetch DRAFT quiz ───────────────────────────────────
+
+    @Test
+    void learnerCannotFetchDraftQuiz() throws Exception {
+        QuizFixture f = buildFixture("inst.lq6@quiz.test");
+        Quiz draftQuiz = createMinimalQuiz(f.course(), "Draft Quiz", QuizStatus.DRAFT);
+        String learnerToken = registerAndLogin("learner.lq6@quiz.test", "password123");
+        enroll("learner.lq6@quiz.test", f.course(), EnrollmentStatus.ACTIVE);
+
+        mockMvc.perform(get("/api/v1/learner/quizzes/{id}", draftQuiz.getId())
+                        .header("Authorization", "Bearer " + learnerToken))
+                .andExpect(status().isNotFound());
+    }
+
+    // ─── 7. Not enrolled learner cannot fetch quiz detail ─────────────────────
+
+    @Test
+    void notEnrolledLearnerCannotFetchQuizDetail() throws Exception {
+        QuizFixture f = buildFixture("inst.lq7@quiz.test");
+        String learnerToken = registerAndLogin("learner.lq7@quiz.test", "password123");
+
+        mockMvc.perform(get("/api/v1/learner/quizzes/{id}", f.quiz().getId())
+                        .header("Authorization", "Bearer " + learnerToken))
+                .andExpect(status().isNotFound());
+    }
+
+    // ─── 8. Start attempt creates IN_PROGRESS attempt ─────────────────────────
+
+    @Test
+    void startAttemptCreatesInProgressAttempt() throws Exception {
+        QuizFixture f = buildFixture("inst.lq8@quiz.test");
+        String learnerToken = registerAndLogin("learner.lq8@quiz.test", "password123");
+        enroll("learner.lq8@quiz.test", f.course(), EnrollmentStatus.ACTIVE);
+
+        mockMvc.perform(post("/api/v1/learner/quizzes/{id}/attempts", f.quiz().getId())
+                        .header("Authorization", "Bearer " + learnerToken))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.quizId").value(f.quiz().getId()))
+                .andExpect(jsonPath("$.status").value("IN_PROGRESS"))
+                .andExpect(jsonPath("$.scorePercentage").doesNotExist())
+                .andExpect(jsonPath("$.answerResults").isArray())
+                .andExpect(jsonPath("$.answerResults").isEmpty());
+    }
+
+    // ─── 9. Starting again reuses existing IN_PROGRESS attempt ────────────────
+
+    @Test
+    void startingAgainReusesExistingInProgressAttempt() throws Exception {
+        QuizFixture f = buildFixture("inst.lq9@quiz.test");
+        String learnerToken = registerAndLogin("learner.lq9@quiz.test", "password123");
+        enroll("learner.lq9@quiz.test", f.course(), EnrollmentStatus.ACTIVE);
+
+        String firstResponse = mockMvc.perform(post("/api/v1/learner/quizzes/{id}/attempts", f.quiz().getId())
+                        .header("Authorization", "Bearer " + learnerToken))
+                .andExpect(status().isOk())
+                .andReturn().getResponse().getContentAsString();
+
+        String secondResponse = mockMvc.perform(post("/api/v1/learner/quizzes/{id}/attempts", f.quiz().getId())
+                        .header("Authorization", "Bearer " + learnerToken))
+                .andExpect(status().isOk())
+                .andReturn().getResponse().getContentAsString();
+
+        Long firstId = objectMapper.readTree(firstResponse).get("id").asLong();
+        Long secondId = objectMapper.readTree(secondResponse).get("id").asLong();
+        assert firstId.equals(secondId) : "Expected same attempt id but got " + firstId + " vs " + secondId;
+    }
+
+    // ─── 10. Submit all correct answers → score 100, passed true ──────────────
+
+    @Test
+    void submitAllCorrectAnswersScores100AndPassed() throws Exception {
+        QuizFixture f = buildFixture("inst.lq10@quiz.test");
+        String learnerToken = registerAndLogin("learner.lq10@quiz.test", "password123");
+        enroll("learner.lq10@quiz.test", f.course(), EnrollmentStatus.ACTIVE);
+
+        Long attemptId = startAttempt(learnerToken, f.quiz().getId());
+
+        String submitBody = objectMapper.writeValueAsString(Map.of(
+                "answers", List.of(
+                        Map.of("questionId", f.q1().getId(), "selectedOptionId", f.q1Correct().getId()),
+                        Map.of("questionId", f.q2().getId(), "selectedOptionId", f.q2Correct().getId())
+                )));
+
+        mockMvc.perform(post("/api/v1/learner/quiz-attempts/{id}/submit", attemptId)
+                        .header("Authorization", "Bearer " + learnerToken)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(submitBody))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.status").value("SUBMITTED"))
+                .andExpect(jsonPath("$.scorePercentage").value(100))
+                .andExpect(jsonPath("$.passed").value(true))
+                .andExpect(jsonPath("$.earnedPoints").value(10))
+                .andExpect(jsonPath("$.totalPoints").value(10));
+    }
+
+    // ─── 11. Submit all wrong answers → score 0, passed false ─────────────────
+
+    @Test
+    void submitAllWrongAnswersScores0AndFailed() throws Exception {
+        QuizFixture f = buildFixture("inst.lq11@quiz.test");
+        String learnerToken = registerAndLogin("learner.lq11@quiz.test", "password123");
+        enroll("learner.lq11@quiz.test", f.course(), EnrollmentStatus.ACTIVE);
+
+        Long attemptId = startAttempt(learnerToken, f.quiz().getId());
+
+        String submitBody = objectMapper.writeValueAsString(Map.of(
+                "answers", List.of(
+                        Map.of("questionId", f.q1().getId(), "selectedOptionId", f.q1Wrong().getId()),
+                        Map.of("questionId", f.q2().getId(), "selectedOptionId", f.q2Wrong().getId())
+                )));
+
+        mockMvc.perform(post("/api/v1/learner/quiz-attempts/{id}/submit", attemptId)
+                        .header("Authorization", "Bearer " + learnerToken)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(submitBody))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.status").value("SUBMITTED"))
+                .andExpect(jsonPath("$.scorePercentage").value(0))
+                .andExpect(jsonPath("$.passed").value(false))
+                .andExpect(jsonPath("$.earnedPoints").value(0))
+                .andExpect(jsonPath("$.totalPoints").value(10));
+    }
+
+    // ─── 12. Submit mixed answers → correct partial score ─────────────────────
+
+    @Test
+    void submitMixedAnswersProducesCorrectPartialScore() throws Exception {
+        // q1=4pts correct, q2=6pts wrong → earned=4, total=10, score=40, passed=false (passingScore=70)
+        QuizFixture f = buildFixture("inst.lq12@quiz.test");
+        String learnerToken = registerAndLogin("learner.lq12@quiz.test", "password123");
+        enroll("learner.lq12@quiz.test", f.course(), EnrollmentStatus.ACTIVE);
+
+        Long attemptId = startAttempt(learnerToken, f.quiz().getId());
+
+        String submitBody = objectMapper.writeValueAsString(Map.of(
+                "answers", List.of(
+                        Map.of("questionId", f.q1().getId(), "selectedOptionId", f.q1Correct().getId()),
+                        Map.of("questionId", f.q2().getId(), "selectedOptionId", f.q2Wrong().getId())
+                )));
+
+        mockMvc.perform(post("/api/v1/learner/quiz-attempts/{id}/submit", attemptId)
+                        .header("Authorization", "Bearer " + learnerToken)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(submitBody))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.earnedPoints").value(4))
+                .andExpect(jsonPath("$.totalPoints").value(10))
+                .andExpect(jsonPath("$.scorePercentage").value(40))
+                .andExpect(jsonPath("$.passed").value(false));
+    }
+
+    // ─── 13. Submit answer results include per-question breakdown ─────────────
+
+    @Test
+    void submitReturnsPerQuestionAnswerResults() throws Exception {
+        QuizFixture f = buildFixture("inst.lq13@quiz.test");
+        String learnerToken = registerAndLogin("learner.lq13@quiz.test", "password123");
+        enroll("learner.lq13@quiz.test", f.course(), EnrollmentStatus.ACTIVE);
+
+        Long attemptId = startAttempt(learnerToken, f.quiz().getId());
+
+        String submitBody = objectMapper.writeValueAsString(Map.of(
+                "answers", List.of(
+                        Map.of("questionId", f.q1().getId(), "selectedOptionId", f.q1Correct().getId()),
+                        Map.of("questionId", f.q2().getId(), "selectedOptionId", f.q2Wrong().getId())
+                )));
+
+        mockMvc.perform(post("/api/v1/learner/quiz-attempts/{id}/submit", attemptId)
+                        .header("Authorization", "Bearer " + learnerToken)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(submitBody))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.answerResults.length()").value(2));
+    }
+
+    // ─── 14. Submit missing answer → 400 ──────────────────────────────────────
+
+    @Test
+    void submitMissingAnswerReturns400() throws Exception {
+        QuizFixture f = buildFixture("inst.lq14@quiz.test");
+        String learnerToken = registerAndLogin("learner.lq14@quiz.test", "password123");
+        enroll("learner.lq14@quiz.test", f.course(), EnrollmentStatus.ACTIVE);
+
+        Long attemptId = startAttempt(learnerToken, f.quiz().getId());
+
+        // Only answering one of two questions
+        String submitBody = objectMapper.writeValueAsString(Map.of(
+                "answers", List.of(
+                        Map.of("questionId", f.q1().getId(), "selectedOptionId", f.q1Correct().getId())
+                )));
+
+        mockMvc.perform(post("/api/v1/learner/quiz-attempts/{id}/submit", attemptId)
+                        .header("Authorization", "Bearer " + learnerToken)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(submitBody))
+                .andExpect(status().isBadRequest());
+    }
+
+    // ─── 15. Submit invalid option for question → 400 ─────────────────────────
+
+    @Test
+    void submitOptionBelongingToWrongQuestionReturns400() throws Exception {
+        QuizFixture f = buildFixture("inst.lq15@quiz.test");
+        String learnerToken = registerAndLogin("learner.lq15@quiz.test", "password123");
+        enroll("learner.lq15@quiz.test", f.course(), EnrollmentStatus.ACTIVE);
+
+        Long attemptId = startAttempt(learnerToken, f.quiz().getId());
+
+        // Swap options: q1's option used for q2 answer
+        String submitBody = objectMapper.writeValueAsString(Map.of(
+                "answers", List.of(
+                        Map.of("questionId", f.q1().getId(), "selectedOptionId", f.q1Correct().getId()),
+                        Map.of("questionId", f.q2().getId(), "selectedOptionId", f.q1Wrong().getId()) // q1's option for q2
+                )));
+
+        mockMvc.perform(post("/api/v1/learner/quiz-attempts/{id}/submit", attemptId)
+                        .header("Authorization", "Bearer " + learnerToken)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(submitBody))
+                .andExpect(status().isBadRequest());
+    }
+
+    // ─── 16. Submit duplicate question in request → 400 ──────────────────────
+
+    @Test
+    void submitDuplicateQuestionReturns400() throws Exception {
+        QuizFixture f = buildFixture("inst.lq16@quiz.test");
+        String learnerToken = registerAndLogin("learner.lq16@quiz.test", "password123");
+        enroll("learner.lq16@quiz.test", f.course(), EnrollmentStatus.ACTIVE);
+
+        Long attemptId = startAttempt(learnerToken, f.quiz().getId());
+
+        // Send q1 twice (duplicate), covering total count of 2 questions
+        String submitBody = objectMapper.writeValueAsString(Map.of(
+                "answers", List.of(
+                        Map.of("questionId", f.q1().getId(), "selectedOptionId", f.q1Correct().getId()),
+                        Map.of("questionId", f.q1().getId(), "selectedOptionId", f.q1Wrong().getId())
+                )));
+
+        mockMvc.perform(post("/api/v1/learner/quiz-attempts/{id}/submit", attemptId)
+                        .header("Authorization", "Bearer " + learnerToken)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(submitBody))
+                .andExpect(status().isBadRequest());
+    }
+
+    // ─── 17. Submit already-submitted attempt → 409 ───────────────────────────
+
+    @Test
+    void submitAlreadySubmittedAttemptReturns409() throws Exception {
+        QuizFixture f = buildFixture("inst.lq17@quiz.test");
+        String learnerToken = registerAndLogin("learner.lq17@quiz.test", "password123");
+        enroll("learner.lq17@quiz.test", f.course(), EnrollmentStatus.ACTIVE);
+
+        Long attemptId = startAttempt(learnerToken, f.quiz().getId());
+        String submitBody = allCorrectBody(f);
+
+        mockMvc.perform(post("/api/v1/learner/quiz-attempts/{id}/submit", attemptId)
+                        .header("Authorization", "Bearer " + learnerToken)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(submitBody))
+                .andExpect(status().isOk());
+
+        // Second submit
+        mockMvc.perform(post("/api/v1/learner/quiz-attempts/{id}/submit", attemptId)
+                        .header("Authorization", "Bearer " + learnerToken)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(submitBody))
+                .andExpect(status().isConflict());
+    }
+
+    // ─── 18. Learner cannot access another learner's attempt → 404 ────────────
+
+    @Test
+    void learnerCannotAccessAnotherLearnersAttempt() throws Exception {
+        QuizFixture f = buildFixture("inst.lq18@quiz.test");
+        String tokenA = registerAndLogin("learner.lq18a@quiz.test", "password123");
+        registerAndLogin("learner.lq18b@quiz.test", "password123");
+        enroll("learner.lq18a@quiz.test", f.course(), EnrollmentStatus.ACTIVE);
+        enroll("learner.lq18b@quiz.test", f.course(), EnrollmentStatus.ACTIVE);
+
+        Long attemptIdA = startAttempt(tokenA, f.quiz().getId());
+
+        // Learner B tries to access Learner A's attempt
+        String tokenB = login("learner.lq18b@quiz.test", "password123");
+        mockMvc.perform(get("/api/v1/learner/quiz-attempts/{id}", attemptIdA)
+                        .header("Authorization", "Bearer " + tokenB))
+                .andExpect(status().isNotFound());
+    }
+
+    // ─── 19. Get attempt result for submitted attempt ─────────────────────────
+
+    @Test
+    void getAttemptResultReturnsSubmittedAttemptWithResults() throws Exception {
+        QuizFixture f = buildFixture("inst.lq19@quiz.test");
+        String learnerToken = registerAndLogin("learner.lq19@quiz.test", "password123");
+        enroll("learner.lq19@quiz.test", f.course(), EnrollmentStatus.ACTIVE);
+
+        Long attemptId = startAttempt(learnerToken, f.quiz().getId());
+        mockMvc.perform(post("/api/v1/learner/quiz-attempts/{id}/submit", attemptId)
+                        .header("Authorization", "Bearer " + learnerToken)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(allCorrectBody(f)))
+                .andExpect(status().isOk());
+
+        mockMvc.perform(get("/api/v1/learner/quiz-attempts/{id}", attemptId)
+                        .header("Authorization", "Bearer " + learnerToken))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.status").value("SUBMITTED"))
+                .andExpect(jsonPath("$.scorePercentage").value(100))
+                .andExpect(jsonPath("$.answerResults.length()").value(2));
+    }
+
+    // ─── 20. Unauthenticated access → 401 ────────────────────────────────────
+
+    @Test
+    void unauthenticatedCannotListQuizzes() throws Exception {
+        mockMvc.perform(get("/api/v1/learner/courses/999/quizzes"))
+                .andExpect(status().isUnauthorized());
+    }
+
+    @Test
+    void unauthenticatedCannotStartAttempt() throws Exception {
+        mockMvc.perform(post("/api/v1/learner/quizzes/999/attempts"))
+                .andExpect(status().isUnauthorized());
+    }
+
+    @Test
+    void unauthenticatedCannotSubmitAttempt() throws Exception {
+        mockMvc.perform(post("/api/v1/learner/quiz-attempts/999/submit")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{}"))
+                .andExpect(status().isUnauthorized());
+    }
+
+    // ─── 21. Cancelled enrollment → 404 ──────────────────────────────────────
+
+    @Test
+    void cancelledEnrollmentCannotListQuizzes() throws Exception {
+        QuizFixture f = buildFixture("inst.lq21@quiz.test");
+        String learnerToken = registerAndLogin("learner.lq21@quiz.test", "password123");
+        enroll("learner.lq21@quiz.test", f.course(), EnrollmentStatus.CANCELLED);
+
+        mockMvc.perform(get("/api/v1/learner/courses/{id}/quizzes", f.course().getId())
+                        .header("Authorization", "Bearer " + learnerToken))
+                .andExpect(status().isNotFound());
+    }
+
+    @Test
+    void cancelledEnrollmentCannotStartAttempt() throws Exception {
+        QuizFixture f = buildFixture("inst.lq22@quiz.test");
+        String learnerToken = registerAndLogin("learner.lq22@quiz.test", "password123");
+        enroll("learner.lq22@quiz.test", f.course(), EnrollmentStatus.CANCELLED);
+
+        mockMvc.perform(post("/api/v1/learner/quizzes/{id}/attempts", f.quiz().getId())
+                        .header("Authorization", "Bearer " + learnerToken))
+                .andExpect(status().isNotFound());
+    }
+
+    // ─── 22. Completed enrollment can still access quizzes ───────────────────
+
+    @Test
+    void completedEnrollmentCanListQuizzes() throws Exception {
+        QuizFixture f = buildFixture("inst.lq23@quiz.test");
+        String learnerToken = registerAndLogin("learner.lq23@quiz.test", "password123");
+        enroll("learner.lq23@quiz.test", f.course(), EnrollmentStatus.COMPLETED);
+
+        mockMvc.perform(get("/api/v1/learner/courses/{id}/quizzes", f.course().getId())
+                        .header("Authorization", "Bearer " + learnerToken))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.length()").value(1));
+    }
+
+    // ─── Helpers ──────────────────────────────────────────────────────────────
+
+    record QuizFixture(
+            Course course, Quiz quiz,
+            Question q1, Question q2,
+            AnswerOption q1Correct, AnswerOption q1Wrong,
+            AnswerOption q2Correct, AnswerOption q2Wrong) {}
+
+    private QuizFixture buildFixture(String instructorEmail) throws Exception {
+        mockMvc.perform(post("/api/v1/auth/register")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(
+                                new RegisterRequest("Test Instructor", instructorEmail, "password123"))))
+                .andExpect(status().isCreated());
+
+        User instructorUser = userRepository.findByEmailIgnoreCase(instructorEmail).orElseThrow();
+        InstructorProfile profile = instructorProfileRepository.save(
+                InstructorProfile.builder()
+                        .user(instructorUser)
+                        .bio("bio")
+                        .expertise("expertise")
+                        .approvalStatus(InstructorApprovalStatus.APPROVED)
+                        .build());
+
+        Category category = categoryRepository.save(
+                Category.builder().name("Cat-" + instructorEmail).build());
+
+        Course course = courseRepository.save(
+                Course.builder()
+                        .title("Course-" + instructorEmail)
+                        .instructorProfile(profile)
+                        .category(category)
+                        .level(CourseLevel.BEGINNER)
+                        .status(CourseStatus.PUBLISHED)
+                        .build());
+
+        Quiz quiz = quizRepository.save(
+                Quiz.builder()
+                        .title("Test Quiz")
+                        .passingScore(70)
+                        .status(QuizStatus.PUBLISHED)
+                        .course(course)
+                        .build());
+
+        // q1 = 4 points, q2 = 6 points → total = 10
+        Question q1 = questionRepository.save(
+                Question.builder()
+                        .quiz(quiz)
+                        .content("Question 1")
+                        .points(4)
+                        .type(QuestionType.MULTIPLE_CHOICE)
+                        .build());
+        quiz.getQuestions().add(q1);
+
+        Question q2 = questionRepository.save(
+                Question.builder()
+                        .quiz(quiz)
+                        .content("Question 2")
+                        .points(6)
+                        .type(QuestionType.MULTIPLE_CHOICE)
+                        .build());
+        quiz.getQuestions().add(q2);
+
+        AnswerOption q1Correct = answerOptionRepository.save(
+                AnswerOption.builder().question(q1).optionText("Correct A").isCorrect(true).build());
+        AnswerOption q1Wrong = answerOptionRepository.save(
+                AnswerOption.builder().question(q1).optionText("Wrong A").isCorrect(false).build());
+        q1.getAnswerOptions().add(q1Correct);
+        q1.getAnswerOptions().add(q1Wrong);
+
+        AnswerOption q2Correct = answerOptionRepository.save(
+                AnswerOption.builder().question(q2).optionText("Correct B").isCorrect(true).build());
+        AnswerOption q2Wrong = answerOptionRepository.save(
+                AnswerOption.builder().question(q2).optionText("Wrong B").isCorrect(false).build());
+        q2.getAnswerOptions().add(q2Correct);
+        q2.getAnswerOptions().add(q2Wrong);
+
+        return new QuizFixture(course, quiz, q1, q2, q1Correct, q1Wrong, q2Correct, q2Wrong);
+    }
+
+    private Quiz createMinimalQuiz(Course course, String title, QuizStatus status) {
+        return quizRepository.save(
+                Quiz.builder()
+                        .title(title)
+                        .passingScore(70)
+                        .status(status)
+                        .course(course)
+                        .build());
+    }
+
+    private LearnerProfile enroll(String learnerEmail, Course course, EnrollmentStatus status) {
+        User user = userRepository.findByEmailIgnoreCase(learnerEmail).orElseThrow();
+        LearnerProfile profile = learnerProfileRepository.findByUserId(user.getId()).orElseThrow();
+        enrollmentRepository.save(Enrollment.builder()
+                .learnerProfile(profile)
+                .course(course)
+                .status(status)
+                .build());
+        return profile;
+    }
+
+    private Long startAttempt(String token, Long quizId) throws Exception {
+        String response = mockMvc.perform(post("/api/v1/learner/quizzes/{id}/attempts", quizId)
+                        .header("Authorization", "Bearer " + token))
+                .andExpect(status().isOk())
+                .andReturn().getResponse().getContentAsString();
+        return objectMapper.readTree(response).get("id").asLong();
+    }
+
+    private String allCorrectBody(QuizFixture f) throws Exception {
+        return objectMapper.writeValueAsString(Map.of(
+                "answers", List.of(
+                        Map.of("questionId", f.q1().getId(), "selectedOptionId", f.q1Correct().getId()),
+                        Map.of("questionId", f.q2().getId(), "selectedOptionId", f.q2Correct().getId())
+                )));
+    }
+
+    private String registerAndLogin(String email, String password) throws Exception {
+        mockMvc.perform(post("/api/v1/auth/register")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(
+                                new RegisterRequest("Test Learner", email, password))))
+                .andExpect(status().isCreated());
+        return login(email, password);
+    }
+
+    private String login(String email, String password) throws Exception {
+        String response = mockMvc.perform(post("/api/v1/auth/login")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(new LoginRequest(email, password))))
+                .andExpect(status().isOk())
+                .andReturn().getResponse().getContentAsString();
+        return objectMapper.readTree(response).get("accessToken").asText();
+    }
+}

--- a/frontend/src/features/dashboard/components/DashboardLayout.tsx
+++ b/frontend/src/features/dashboard/components/DashboardLayout.tsx
@@ -1,5 +1,5 @@
 import { type ComponentType, useState } from 'react';
-import { NavLink, Outlet } from 'react-router-dom';
+import { NavLink, Outlet, useNavigate } from 'react-router-dom';
 import {
   LayoutDashboard,
   BookOpen,
@@ -10,6 +10,7 @@ import {
   Settings,
   Bell,
   GraduationCap,
+  ArrowRightLeft,
   Menu,
   X,
 } from 'lucide-react';
@@ -45,7 +46,8 @@ function getInitials(name: string): string {
 }
 
 export default function DashboardLayout() {
-  const { user, activeProfile } = useAuth();
+  const { user, activeProfile, setActiveProfile } = useAuth();
+  const navigate = useNavigate();
   const [sidebarOpen, setSidebarOpen] = useState(false);
 
   const displayName  = user?.fullName ?? 'User';
@@ -58,13 +60,16 @@ export default function DashboardLayout() {
     userRoles.includes('ROLE_ADMIN') &&
     !(user?.availableProfiles ?? []).includes('INSTRUCTOR');
 
+  const isApprovedInstructor = (user?.availableProfiles ?? []).includes('INSTRUCTOR');
+
   const navItems = NAV_ITEMS.filter(
     item => !item.roleRequired || userRoles.includes(item.roleRequired),
   );
 
-  const showInstructorCta = !isAdminOnly && user?.instructorApprovalStatus === null;
-  const showPendingNote   = !isAdminOnly && user?.instructorApprovalStatus === 'PENDING';
+  const showInstructorCta = !isAdminOnly && !isApprovedInstructor && user?.instructorApprovalStatus === null;
+  const showPendingNote   = !isAdminOnly && !isApprovedInstructor && user?.instructorApprovalStatus === 'PENDING';
   const showSidebarCta    = showInstructorCta || showPendingNote;
+  const showProfileSwitchCard = isApprovedInstructor;
 
   const closeSidebar = () => setSidebarOpen(false);
 
@@ -223,6 +228,47 @@ export default function DashboardLayout() {
                     </span>
                   </div>
                 )}
+              </div>
+            </div>
+          )}
+
+          {/* Profile switch card — shown only for approved instructors */}
+          {showProfileSwitchCard && (
+            <div className="p-4 pt-2">
+              <div className="border border-border-default rounded-lg p-3.5">
+                <div className="flex items-center gap-2 mb-1.5">
+                  <ArrowRightLeft size={14} className="text-salem flex-shrink-0" aria-hidden="true" />
+                  <span className="text-body-sm font-medium text-text-primary">Profile</span>
+                </div>
+                <p className="text-caption text-text-secondary mb-3 leading-relaxed">
+                  {activeProfile === 'INSTRUCTOR'
+                    ? 'You are browsing as an instructor.'
+                    : 'You are browsing as a learner.'}
+                </p>
+                <button
+                  type="button"
+                  onClick={() => {
+                    closeSidebar();
+                    if (activeProfile === 'INSTRUCTOR') {
+                      setActiveProfile('LEARNER');
+                    } else {
+                      setActiveProfile('INSTRUCTOR');
+                      navigate('/instructor/courses');
+                    }
+                  }}
+                  aria-label={
+                    activeProfile === 'INSTRUCTOR'
+                      ? 'Switch to learner profile'
+                      : 'Switch to instructor profile'
+                  }
+                  className={cn(
+                    'inline-flex items-center text-body-sm font-medium text-salem',
+                    'hover:text-salem-400 transition-colors duration-fast',
+                    'focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-salem rounded-sm',
+                  )}
+                >
+                  {activeProfile === 'INSTRUCTOR' ? 'Switch to learner' : 'Switch to instructor'}
+                </button>
               </div>
             </div>
           )}

--- a/frontend/src/features/instructor/components/InstructorLayout.tsx
+++ b/frontend/src/features/instructor/components/InstructorLayout.tsx
@@ -1,4 +1,4 @@
-import { Outlet, Link } from 'react-router-dom';
+import { Outlet, useNavigate } from 'react-router-dom';
 import { Bell, ArrowLeft } from 'lucide-react';
 import { useAuth } from '../../../context/AuthContext';
 import { cn } from '../../../lib/cn';
@@ -14,7 +14,8 @@ function getInitials(name: string): string {
 }
 
 export default function InstructorLayout() {
-  const { user } = useAuth();
+  const { user, setActiveProfile } = useAuth();
+  const navigate = useNavigate();
   const displayName = user?.fullName ?? 'User';
   const initials = user?.fullName ? getInitials(user.fullName) : '?';
 
@@ -33,8 +34,12 @@ export default function InstructorLayout() {
 
         {/* Left: back link + logo + teaching label */}
         <div className="flex items-center gap-3 flex-1 min-w-0">
-          <Link
-            to="/dashboard"
+          <button
+            type="button"
+            onClick={() => {
+              setActiveProfile('LEARNER');
+              navigate('/dashboard');
+            }}
             className={cn(
               'flex items-center gap-1.5 text-body-sm text-text-secondary flex-shrink-0',
               'hover:text-text-primary transition-colors duration-fast',
@@ -44,7 +49,7 @@ export default function InstructorLayout() {
           >
             <ArrowLeft size={14} aria-hidden="true" />
             <span className="hidden sm:inline">Dashboard</span>
-          </Link>
+          </button>
 
           <span className="text-border-default select-none flex-shrink-0" aria-hidden="true">/</span>
 


### PR DESCRIPTION
Adds learner quiz-taking backend support.

Implemented:
- Published quiz listing for enrolled learners
- Learner-safe quiz detail without correct-answer leakage
- Quiz attempts and attempt answers
- Attempt start/reuse behavior
- Submit attempt with deterministic scoring
- Attempt result retrieval
- Enrollment-gated access control
- 25 integration tests

Scoring:
- one selected option per question
- correct option earns full question points
- incorrect option earns 0
- scorePercentage = floor(earnedPoints * 100 / totalPoints)
- passed = scorePercentage >= quiz.passingScore

Security:
- no token -> 401
- non-learner / not enrolled / cancelled enrollment / draft / archived / missing quiz -> protected via 404-style enumeration prevention where appropriate
- attempts are owned by learner profile

Tests:
- ./mvnw test -> 162 tests, 0 failures